### PR TITLE
2 [FRONTEND] - auth screens login signup UI

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,13 +1,27 @@
-import { Image } from "expo-image";
-import React, { useEffect, useState } from "react";
-import { Platform, StyleSheet, Text, TextInput, View } from "react-native";
-import { supabase } from "../../lib/supabase";
+import { Image } from 'expo-image';
+import React, { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
-import { HelloWave } from "@/components/hello-wave";
-import ParallaxScrollView from "@/components/parallax-scroll-view";
-import { ThemedText } from "@/components/themed-text";
-import { ThemedView } from "@/components/themed-view";
-import { Link } from "expo-router";
+import {
+  FontFamilies,
+  LandingAssets,
+  Palette,
+  Radius,
+  Spacing,
+  Typography,
+} from '@/constants/design';
+import { supabase } from '@/lib/supabase';
 
 export default function HomeScreen() {
   // Auth state
@@ -15,6 +29,7 @@ export default function HomeScreen() {
   const [password, setPassword] = useState("");
   const [user, setUser] = useState<any>(null);
   const [authError, setAuthError] = useState<string | null>(null);
+  const [authMessage, setAuthMessage] = useState<string | null>(null);
 
   // Items state
   const [items, setItems] = useState<any[]>([]);
@@ -43,175 +58,325 @@ export default function HomeScreen() {
       });
   }, [user]);
 
-  // Sign in handler
   const handleSignIn = async () => {
     setAuthError(null);
-    const { data, error } = await supabase.auth.signInWithPassword({
+    setAuthMessage(null);
+
+    const { data, error: signInError } = await supabase.auth.signInWithPassword({
       email,
       password,
     });
-    if (error) setAuthError(error.message);
-    else setUser(data.user);
+
+    if (signInError) {
+      setAuthError(signInError.message);
+      return;
+    }
+
+    setUser(data.user);
   };
 
-  useEffect(() => {
-    supabase
-      .from("items")
-      .select("*")
-      .then(({ data, error }) => {
-        if (error) setError(error.message);
-        else setItems(data || []);
-        setLoading(false);
-      });
-  }, []);
+  const handleSignUp = async () => {
+    setAuthError(null);
+    setAuthMessage(null);
+
+    const { data, error: signUpError } = await supabase.auth.signUp({
+      email,
+      password,
+    });
+
+    if (signUpError) {
+      setAuthError(signUpError.message);
+      return;
+    }
+
+    if (data.user) {
+      setUser(data.user);
+      setAuthMessage('Account created. Check your email if confirmation is required.');
+    }
+  };
 
   return (
-    <ParallaxScrollView
-      headerBackgroundColor={{ light: "#A1CEDC", dark: "#1D3D47" }}
-      headerImage={
-        <Image
-          source={require("@/assets/images/partial-react-logo.png")}
-          style={styles.reactLogo}
-        />
-      }
-    >
-      <ThemedView style={styles.titleContainer}>
-        <ThemedText type="title">Welcome!</ThemedText>
-        <HelloWave />
-      </ThemedView>
-      {/* Supabase items test display */}
-      {/* Supabase Auth and Items Test Display */}
-      <View style={{ padding: 16 }}>
-        <Text style={{ fontWeight: "bold", marginBottom: 8 }}>
-          Supabase Items Table Test
-        </Text>
-        {!user && (
-          <View>
-            <Text>Email:</Text>
-            <TextInput
-              style={{ borderWidth: 1, marginBottom: 8, padding: 4 }}
-              autoCapitalize="none"
-              value={email}
-              onChangeText={setEmail}
-              placeholder="email"
-            />
-            <Text>Password:</Text>
-            <TextInput
-              style={{ borderWidth: 1, marginBottom: 8, padding: 4 }}
-              secureTextEntry
-              value={password}
-              onChangeText={setPassword}
-              placeholder="password"
-            />
-            <Text
-              style={{ color: "blue", marginBottom: 8 }}
-              onPress={handleSignIn}
-            >
-              Sign In
-            </Text>
-            {authError && <Text style={{ color: "red" }}>{authError}</Text>}
-          </View>
-        )}
-        {user && (
-          <View>
-            <Text>User: {user.email}</Text>
-            {loading && <Text>Loading...</Text>}
-            {error && <Text style={{ color: "red" }}>{error}</Text>}
-            {!loading && !error && items.length === 0 && (
-              <Text>No items found.</Text>
-            )}
-            {!loading && !error && items.length > 0 && (
-              <View>
-                {items.map((item) => (
-                  <Text key={item.id}>
-                    {item.category} - {item.id}
-                  </Text>
-                ))}
-              </View>
-            )}
-          </View>
-        )}
-      </View>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 1: Try it</ThemedText>
-        <ThemedText>
-          Edit{" "}
-          <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText>{" "}
-          to see changes. Press{" "}
-          <ThemedText type="defaultSemiBold">
-            {Platform.select({
-              ios: "cmd + d",
-              android: "cmd + m",
-              web: "F12",
-            })}
-          </ThemedText>{" "}
-          to open developer tools.
-        </ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <Link href="/modal">
-          <Link.Trigger>
-            <ThemedText type="subtitle">Step 2: Explore</ThemedText>
-          </Link.Trigger>
-          <Link.Preview />
-          <Link.Menu>
-            <Link.MenuAction
-              title="Action"
-              icon="cube"
-              onPress={() => alert("Action pressed")}
-            />
-            <Link.MenuAction
-              title="Share"
-              icon="square.and.arrow.up"
-              onPress={() => alert("Share pressed")}
-            />
-            <Link.Menu title="More" icon="ellipsis">
-              <Link.MenuAction
-                title="Delete"
-                icon="trash"
-                destructive
-                onPress={() => alert("Delete pressed")}
-              />
-            </Link.Menu>
-          </Link.Menu>
-        </Link>
+    <View style={styles.screen}>
+      <Image
+        source={{ uri: LandingAssets.backgroundImage }}
+        style={styles.backgroundImage}
+        contentFit="cover"
+        blurRadius={2}
+      />
+      <View style={styles.backgroundScrim} />
+      <View style={styles.backgroundGradient} />
 
-        <ThemedText>
-          {`Tap the Explore tab to learn more about what's included in this starter app.`}
-        </ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 3: Get a fresh start</ThemedText>
-        <ThemedText>
-          {`When you're ready, run `}
-          <ThemedText type="defaultSemiBold">
-            npm run reset-project
-          </ThemedText>{" "}
-          to get a fresh <ThemedText type="defaultSemiBold">app</ThemedText>{" "}
-          directory. This will move the current{" "}
-          <ThemedText type="defaultSemiBold">app</ThemedText> to{" "}
-          <ThemedText type="defaultSemiBold">app-example</ThemedText>.
-        </ThemedText>
-      </ThemedView>
-    </ParallaxScrollView>
+      <SafeAreaView style={styles.safeArea}>
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+          style={styles.keyboardAvoiding}
+        >
+          <ScrollView
+            contentContainerStyle={styles.scrollContent}
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+          >
+            <View style={styles.card}>
+              <View style={styles.logoSection}>
+                <Text style={styles.brandTitle}>FITTED</Text>
+                <Text style={styles.brandTagline}>Curate Your Collection</Text>
+              </View>
+
+              {!user ? (
+                <View style={styles.authSection}>
+                  <View style={styles.fieldGroup}>
+                    <Text style={styles.fieldLabel}>Email</Text>
+                    <TextInput
+                      autoCapitalize="none"
+                      autoComplete="email"
+                      keyboardType="email-address"
+                      onChangeText={setEmail}
+                      placeholder="you@example.com"
+                      placeholderTextColor={Palette.onSurfaceVariant}
+                      style={styles.input}
+                      value={email}
+                    />
+                  </View>
+
+                  <View style={styles.fieldGroup}>
+                    <Text style={styles.fieldLabel}>Password</Text>
+                    <TextInput
+                      autoCapitalize="none"
+                      autoComplete="password"
+                      onChangeText={setPassword}
+                      placeholder="Enter your password"
+                      placeholderTextColor={Palette.onSurfaceVariant}
+                      secureTextEntry
+                      style={styles.input}
+                      value={password}
+                    />
+                  </View>
+
+                  <View style={styles.actionStack}>
+                    <Pressable
+                      accessibilityRole="button"
+                      onPress={handleSignUp}
+                      style={({ pressed }) => [
+                        styles.primaryButton,
+                        pressed && styles.buttonPressed,
+                      ]}
+                    >
+                      <Text style={styles.primaryButtonText}>Create Account</Text>
+                    </Pressable>
+
+                    <Pressable
+                      accessibilityRole="button"
+                      onPress={handleSignIn}
+                      style={({ pressed }) => [
+                        styles.secondaryButton,
+                        pressed && styles.secondaryButtonPressed,
+                      ]}
+                    >
+                      <Text style={styles.secondaryButtonText}>Sign In</Text>
+                    </Pressable>
+                  </View>
+
+                  {authError ? <Text style={styles.errorText}>{authError}</Text> : null}
+                  {authMessage ? <Text style={styles.messageText}>{authMessage}</Text> : null}
+                </View>
+              ) : (
+                <View style={styles.authSection}>
+                  <Text style={styles.signedInLabel}>Signed in as</Text>
+                  <Text style={styles.signedInEmail}>{user.email}</Text>
+
+                  {loading ? (
+                    <ActivityIndicator color={Palette.primary} style={styles.loader} />
+                  ) : null}
+                  {error ? <Text style={styles.errorText}>{error}</Text> : null}
+                  {!loading && !error && items.length === 0 ? (
+                    <Text style={styles.emptyStateText}>No items found.</Text>
+                  ) : null}
+                  {!loading && !error && items.length > 0 ? (
+                    <View style={styles.itemsList}>
+                      {items.map((item) => (
+                        <Text key={item.id} style={styles.itemText}>
+                          {item.category} - {item.id}
+                        </Text>
+                      ))}
+                    </View>
+                  ) : null}
+                </View>
+              )}
+
+              <Text style={styles.footerText}>
+                By continuing, you agree to our{' '}
+                <Text style={styles.footerLink}>Terms</Text> and{' '}
+                <Text style={styles.footerLink}>Privacy</Text>.
+              </Text>
+            </View>
+          </ScrollView>
+        </KeyboardAvoidingView>
+      </SafeAreaView>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  titleContainer: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 8,
+  screen: {
+    flex: 1,
+    backgroundColor: Palette.surface,
   },
-  stepContainer: {
-    gap: 8,
-    marginBottom: 8,
+  backgroundImage: {
+    ...StyleSheet.absoluteFillObject,
+    opacity: 0.4,
   },
-  reactLogo: {
-    height: 178,
-    width: 290,
-    bottom: 0,
-    left: 0,
-    position: "absolute",
+  backgroundScrim: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: Palette.surface,
+    opacity: 0.35,
+  },
+  backgroundGradient: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(251, 249, 249, 0.72)',
+  },
+  safeArea: {
+    flex: 1,
+  },
+  keyboardAvoiding: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    paddingHorizontal: Spacing.containerMargin,
+    paddingVertical: Spacing.stackLg,
+  },
+  card: {
+    width: '100%',
+    maxWidth: 448,
+    alignSelf: 'center',
+  },
+  logoSection: {
+    alignItems: 'center',
+    marginBottom: Spacing.stackXl,
+  },
+  brandTitle: {
+    ...Typography.displayLg,
+    color: Palette.primary,
+    letterSpacing: 8,
+    textTransform: 'uppercase',
+    marginBottom: Spacing.stackSm,
+  },
+  brandTagline: {
+    ...Typography.labelSm,
+    color: Palette.onSurfaceVariant,
+    letterSpacing: 2.4,
+  },
+  authSection: {
+    width: '100%',
+    gap: Spacing.stackMd,
+  },
+  fieldGroup: {
+    gap: Spacing.stackSm,
+  },
+  fieldLabel: {
+    ...Typography.labelSm,
+    color: Palette.onSurfaceVariant,
+    letterSpacing: 1.2,
+  },
+  input: {
+    ...Typography.bodyMd,
+    height: 52,
+    borderWidth: 1,
+    borderColor: Palette.outlineVariant,
+    borderRadius: Radius.md,
+    backgroundColor: Palette.surfaceContainerLowest,
+    color: Palette.onSurface,
+    paddingHorizontal: Spacing.stackMd,
+  },
+  actionStack: {
+    gap: Spacing.stackMd,
+    marginTop: Spacing.stackSm,
+  },
+  primaryButton: {
+    height: 52,
+    borderRadius: Radius.md,
+    backgroundColor: Palette.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#000000',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.12,
+    shadowRadius: 16,
+    elevation: 4,
+  },
+  primaryButtonText: {
+    ...Typography.bodyMd,
+    color: Palette.onPrimary,
+  },
+  secondaryButton: {
+    height: 52,
+    borderRadius: Radius.md,
+    borderWidth: 1,
+    borderColor: Palette.outlineVariant,
+    backgroundColor: Palette.surfaceContainerLowest,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  secondaryButtonText: {
+    ...Typography.bodyMd,
+    color: Palette.onSurface,
+  },
+  buttonPressed: {
+    opacity: 0.9,
+  },
+  secondaryButtonPressed: {
+    backgroundColor: Palette.surfaceContainerLow,
+  },
+  errorText: {
+    ...Typography.bodyMd,
+    color: Palette.error,
+    textAlign: 'center',
+  },
+  messageText: {
+    ...Typography.bodyMd,
+    color: Palette.onSurfaceVariant,
+    textAlign: 'center',
+  },
+  signedInLabel: {
+    ...Typography.labelSm,
+    color: Palette.onSurfaceVariant,
+    textAlign: 'center',
+  },
+  signedInEmail: {
+    ...Typography.titleLg,
+    color: Palette.onSurface,
+    textAlign: 'center',
+  },
+  loader: {
+    marginTop: Spacing.stackSm,
+  },
+  emptyStateText: {
+    ...Typography.bodyMd,
+    color: Palette.onSurfaceVariant,
+    textAlign: 'center',
+  },
+  itemsList: {
+    gap: Spacing.stackSm,
+    marginTop: Spacing.stackSm,
+  },
+  itemText: {
+    ...Typography.bodyMd,
+    color: Palette.onSurface,
+    textAlign: 'center',
+  },
+  footerText: {
+    ...Typography.labelSm,
+    color: Palette.onSurfaceVariant,
+    textAlign: 'center',
+    marginTop: Spacing.stackXl,
+    textTransform: 'none',
+    letterSpacing: 0.4,
+    lineHeight: 18,
+  },
+  footerLink: {
+    color: Palette.primary,
+    textDecorationLine: 'underline',
+    fontFamily: FontFamilies.bodySemiBold,
   },
 });

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,4 +1,5 @@
 import { Image } from 'expo-image';
+import { useRouter } from 'expo-router';
 import React, { useEffect, useState } from 'react';
 import {
   ActivityIndicator,
@@ -21,9 +22,17 @@ import {
   Spacing,
   Typography,
 } from '@/constants/design';
+import { setSignUpDraft } from '@/lib/sign-up-draft';
 import { supabase } from '@/lib/supabase';
+import {
+  formatAuthError,
+  normalizeEmail,
+  validateAuthCredentials,
+} from '@/lib/validation';
 
 export default function HomeScreen() {
+  const router = useRouter();
+
   // Auth state
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -62,37 +71,37 @@ export default function HomeScreen() {
     setAuthError(null);
     setAuthMessage(null);
 
+    const validationError = validateAuthCredentials(email, password);
+    if (validationError) {
+      setAuthError(validationError);
+      return;
+    }
+
     const { data, error: signInError } = await supabase.auth.signInWithPassword({
-      email,
+      email: normalizeEmail(email),
       password,
     });
 
     if (signInError) {
-      setAuthError(signInError.message);
+      setAuthError(formatAuthError(signInError.message));
       return;
     }
 
     setUser(data.user);
   };
 
-  const handleSignUp = async () => {
+  const handleSignUp = () => {
     setAuthError(null);
     setAuthMessage(null);
 
-    const { data, error: signUpError } = await supabase.auth.signUp({
-      email,
-      password,
-    });
-
-    if (signUpError) {
-      setAuthError(signUpError.message);
+    const validationError = validateAuthCredentials(email, password);
+    if (validationError) {
+      setAuthError(validationError);
       return;
     }
 
-    if (data.user) {
-      setUser(data.user);
-      setAuthMessage('Account created. Check your email if confirmation is required.');
-    }
+    setSignUpDraft(normalizeEmail(email), password);
+    router.push('/onboarding/personal-info');
   };
 
   return (

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,6 +1,17 @@
+import {
+  Manrope_400Regular,
+  Manrope_600SemiBold,
+  useFonts as useManropeFonts,
+} from '@expo-google-fonts/manrope';
+import {
+  Newsreader_500Medium,
+  useFonts as useNewsreaderFonts,
+} from '@expo-google-fonts/newsreader';
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { Stack } from 'expo-router';
+import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
+import { useEffect } from 'react';
 import 'react-native-reanimated';
 
 import { useColorScheme } from '@/hooks/use-color-scheme';
@@ -9,8 +20,27 @@ export const unstable_settings = {
   anchor: '(tabs)',
 };
 
+SplashScreen.preventAutoHideAsync();
+
 export default function RootLayout() {
   const colorScheme = useColorScheme();
+  const [manropeLoaded] = useManropeFonts({
+    Manrope_400Regular,
+    Manrope_600SemiBold,
+  });
+  const [newsreaderLoaded] = useNewsreaderFonts({
+    Newsreader_500Medium,
+  });
+
+  useEffect(() => {
+    if (manropeLoaded && newsreaderLoaded) {
+      SplashScreen.hideAsync();
+    }
+  }, [manropeLoaded, newsreaderLoaded]);
+
+  if (!manropeLoaded || !newsreaderLoaded) {
+    return null;
+  }
 
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -46,6 +46,10 @@ export default function RootLayout() {
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen
+          name="onboarding/personal-info"
+          options={{ headerShown: false, presentation: 'card' }}
+        />
         <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
       </Stack>
       <StatusBar style="auto" />

--- a/app/onboarding/personal-info.tsx
+++ b/app/onboarding/personal-info.tsx
@@ -1,0 +1,364 @@
+import { useRouter } from 'expo-router';
+import { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { EditorialTextField } from '@/components/onboarding/EditorialTextField';
+import { HeightPickerField } from '@/components/onboarding/HeightPickerField';
+import { IconSymbol } from '@/components/ui/icon-symbol';
+import { Palette, Radius, Spacing, Typography } from '@/constants/design';
+import { signUpWithProfile } from '@/lib/sign-up';
+import { clearSignUpDraft, getSignUpDraft } from '@/lib/sign-up-draft';
+import { validateProfileForm } from '@/lib/validation';
+
+type Gender = 'female' | 'male' | 'other';
+
+const GENDER_OPTIONS: { value: Gender; label: string }[] = [
+  { value: 'female', label: 'Female' },
+  { value: 'male', label: 'Male' },
+  { value: 'other', label: 'Other' },
+];
+
+export default function PersonalInfoScreen() {
+  const router = useRouter();
+  const [fullName, setFullName] = useState('');
+  const [age, setAge] = useState('');
+  const [heightFeet, setHeightFeet] = useState(5);
+  const [heightInches, setHeightInches] = useState(8);
+  const [gender, setGender] = useState<Gender>('female');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!getSignUpDraft()) {
+      router.replace('/(tabs)');
+    }
+  }, [router]);
+
+  const handleContinue = async () => {
+    const draft = getSignUpDraft();
+    if (!draft) {
+      setError('Session expired. Go back and enter your email and password again.');
+      return;
+    }
+
+    const validationError = validateProfileForm({ fullName, age });
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    const trimmedName = fullName.trim();
+    const parsedAge = Number.parseInt(age, 10);
+
+    setSubmitting(true);
+    setError(null);
+
+    const totalHeightInches = heightFeet * 12 + heightInches;
+
+    const result = await signUpWithProfile({
+      email: draft.email,
+      password: draft.password,
+      name: trimmedName,
+      age: parsedAge,
+      heightInches: totalHeightInches,
+      gender,
+    });
+
+    setSubmitting(false);
+
+    if (!result.ok) {
+      setError(result.message);
+      return;
+    }
+
+    clearSignUpDraft();
+    router.replace('/(tabs)');
+  };
+
+  return (
+    <View style={styles.screen}>
+      <View style={styles.decorativeCircle} pointerEvents="none" />
+
+      <SafeAreaView style={styles.safeArea}>
+        <View style={styles.header}>
+          <Pressable
+            accessibilityLabel="Go back"
+            accessibilityRole="button"
+            onPress={() => router.back()}
+            style={({ pressed }) => [styles.backButton, pressed && styles.backButtonPressed]}
+          >
+            <IconSymbol color={Palette.onSurfaceVariant} name="chevron.left" size={24} />
+          </Pressable>
+          <Text style={styles.headerLabel}>Getting to Know You</Text>
+          <View style={styles.headerSpacer} />
+        </View>
+
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+          style={styles.keyboardAvoiding}
+        >
+          <ScrollView
+            contentContainerStyle={styles.scrollContent}
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+          >
+            <View style={styles.content}>
+              <View style={styles.introSection}>
+                <Text style={styles.title}>Tell us about yourself</Text>
+                <Text style={styles.subtitle}>
+                  To curate a wardrobe that perfectly suits you, we need a few basic details to get
+                  started.
+                </Text>
+              </View>
+
+              <View style={styles.formSection}>
+                <EditorialTextField
+                  autoComplete="name"
+                  label="Full Name"
+                  onChangeText={setFullName}
+                  placeholder="e.g. Jane Doe"
+                  value={fullName}
+                />
+
+                <EditorialTextField
+                  label="Age"
+                  maxLength={3}
+                  numericOnly
+                  onChangeText={setAge}
+                  placeholder="Enter your age"
+                  value={age}
+                />
+
+                <HeightPickerField
+                  feet={heightFeet}
+                  inches={heightInches}
+                  onFeetChange={setHeightFeet}
+                  onInchesChange={setHeightInches}
+                />
+
+                <View style={styles.genderSection}>
+                  <Text style={styles.genderLabel}>I identify as</Text>
+                  <View style={styles.genderRow}>
+                    {GENDER_OPTIONS.map((option) => {
+                      const isActive = gender === option.value;
+                      return (
+                        <Pressable
+                          key={option.value}
+                          accessibilityRole="button"
+                          accessibilityState={{ selected: isActive }}
+                          onPress={() => setGender(option.value)}
+                          style={({ pressed }) => [
+                            styles.segmentButton,
+                            isActive && styles.segmentButtonActive,
+                            pressed && !isActive && styles.segmentButtonPressed,
+                          ]}
+                        >
+                          <Text
+                            style={[
+                              styles.segmentButtonText,
+                              isActive && styles.segmentButtonTextActive,
+                            ]}
+                          >
+                            {option.label}
+                          </Text>
+                        </Pressable>
+                      );
+                    })}
+                  </View>
+                </View>
+              </View>
+
+              {error ? <Text style={styles.errorText}>{error}</Text> : null}
+            </View>
+          </ScrollView>
+
+          <View style={styles.footer}>
+            <Pressable
+              accessibilityRole="button"
+              disabled={submitting}
+              onPress={handleContinue}
+              style={({ pressed }) => [
+                styles.continueButton,
+                submitting && styles.continueButtonDisabled,
+                pressed && !submitting && styles.continueButtonPressed,
+              ]}
+            >
+              {submitting ? (
+                <ActivityIndicator color={Palette.onPrimary} />
+              ) : (
+                <>
+                  <Text style={styles.continueButtonText}>Continue</Text>
+                  <IconSymbol color={Palette.onPrimary} name="arrow.forward" size={20} />
+                </>
+              )}
+            </Pressable>
+          </View>
+        </KeyboardAvoidingView>
+      </SafeAreaView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: Palette.background,
+  },
+  decorativeCircle: {
+    position: 'absolute',
+    right: -48,
+    top: '50%',
+    marginTop: -128,
+    width: 256,
+    height: 256,
+    borderRadius: Radius.full,
+    backgroundColor: Palette.surfaceVariant,
+    opacity: 0.3,
+  },
+  safeArea: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: Spacing.containerMargin,
+    paddingTop: Spacing.stackMd,
+    paddingBottom: Spacing.stackMd,
+  },
+  backButton: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginLeft: -8,
+    borderRadius: Radius.full,
+  },
+  backButtonPressed: {
+    backgroundColor: Palette.surfaceContainer,
+  },
+  headerLabel: {
+    ...Typography.labelSm,
+    color: Palette.outline,
+    letterSpacing: 2,
+    textAlign: 'center',
+    flex: 1,
+  },
+  headerSpacer: {
+    width: 40,
+  },
+  keyboardAvoiding: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+    paddingHorizontal: Spacing.containerMargin,
+    paddingTop: Spacing.stackXl,
+    paddingBottom: Spacing.stackLg,
+  },
+  content: {
+    maxWidth: 448,
+    width: '100%',
+    alignSelf: 'center',
+  },
+  introSection: {
+    marginBottom: Spacing.stackXl,
+  },
+  title: {
+    ...Typography.displayLg,
+    color: Palette.primary,
+    marginBottom: Spacing.stackSm,
+  },
+  subtitle: {
+    ...Typography.bodyMd,
+    color: Palette.onSurfaceVariant,
+  },
+  formSection: {
+    gap: Spacing.stackLg,
+  },
+  genderSection: {
+    gap: Spacing.stackSm,
+    paddingTop: Spacing.stackSm,
+  },
+  genderLabel: {
+    ...Typography.labelSm,
+    color: Palette.onSurfaceVariant,
+    letterSpacing: 1.2,
+    marginBottom: Spacing.stackSm,
+  },
+  genderRow: {
+    flexDirection: 'row',
+    gap: Spacing.gutter,
+  },
+  segmentButton: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: Palette.outlineVariant,
+    borderRadius: Radius.sm,
+    paddingVertical: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  segmentButtonActive: {
+    backgroundColor: Palette.primary,
+    borderColor: Palette.primary,
+  },
+  segmentButtonPressed: {
+    backgroundColor: Palette.surfaceContainer,
+  },
+  segmentButtonText: {
+    ...Typography.bodyMd,
+    color: Palette.primary,
+  },
+  segmentButtonTextActive: {
+    color: Palette.onPrimary,
+  },
+  footer: {
+    paddingHorizontal: Spacing.containerMargin,
+    paddingTop: Spacing.stackXl,
+    paddingBottom: Spacing.stackMd,
+    maxWidth: 448,
+    width: '100%',
+    alignSelf: 'center',
+  },
+  continueButton: {
+    height: 52,
+    borderRadius: Radius.md,
+    backgroundColor: Palette.primary,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: Spacing.stackSm,
+    shadowColor: '#000000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.1,
+    shadowRadius: 8,
+    elevation: 2,
+  },
+  continueButtonPressed: {
+    opacity: 0.9,
+    transform: [{ scale: 0.98 }],
+  },
+  continueButtonDisabled: {
+    opacity: 0.7,
+  },
+  errorText: {
+    ...Typography.bodyMd,
+    color: Palette.error,
+    marginTop: Spacing.stackMd,
+  },
+  continueButtonText: {
+    ...Typography.titleLg,
+    color: Palette.onPrimary,
+  },
+});

--- a/components/onboarding/EditorialTextField.tsx
+++ b/components/onboarding/EditorialTextField.tsx
@@ -1,0 +1,63 @@
+// Text input component for the onboarding process
+import { StyleSheet, Text, TextInput, type TextInputProps, View } from 'react-native';
+
+import { Palette, Spacing, Typography } from '@/constants/design';
+
+type EditorialTextFieldProps = {
+  label: string;
+  value: string;
+  onChangeText: (text: string) => void;
+  placeholder?: string;
+  autoComplete?: TextInputProps['autoComplete'];
+  maxLength?: number;
+  numericOnly?: boolean;
+};
+
+export function EditorialTextField({
+  label,
+  value,
+  onChangeText,
+  placeholder,
+  autoComplete,
+  maxLength,
+  numericOnly = false,
+}: EditorialTextFieldProps) {
+  const handleChange = (text: string) => {
+    onChangeText(numericOnly ? text.replace(/\D/g, '') : text);
+  };
+
+  return (
+    <View style={styles.fieldGroup}>
+      <Text style={styles.label}>{label}</Text>
+      <TextInput
+        autoComplete={autoComplete}
+        keyboardType={numericOnly ? 'number-pad' : 'default'}
+        maxLength={maxLength}
+        onChangeText={handleChange}
+        placeholder={placeholder}
+        placeholderTextColor={Palette.outline}
+        style={styles.input}
+        value={value}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  fieldGroup: {
+    gap: Spacing.stackSm,
+  },
+  label: {
+    ...Typography.labelSm,
+    color: Palette.onSurfaceVariant,
+    letterSpacing: 1.2,
+  },
+  input: {
+    ...Typography.titleLg,
+    color: Palette.primary,
+    borderBottomWidth: 1,
+    borderBottomColor: Palette.outlineVariant,
+    paddingVertical: Spacing.stackSm,
+    paddingHorizontal: 0,
+  },
+});

--- a/components/onboarding/EditorialWheelPicker.tsx
+++ b/components/onboarding/EditorialWheelPicker.tsx
@@ -1,0 +1,110 @@
+// Wheel picker component for the height field in onboarding process
+import { useEffect, useRef } from 'react';
+import {
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import { Palette, Typography } from '@/constants/design';
+
+const ITEM_HEIGHT = 44;
+const VISIBLE_COUNT = 3;
+const PICKER_HEIGHT = ITEM_HEIGHT * VISIBLE_COUNT;
+
+type EditorialWheelPickerProps = {
+  values: number[];
+  selected: number;
+  onSelect: (value: number) => void;
+};
+
+export function EditorialWheelPicker({
+  values,
+  selected,
+  onSelect,
+}: EditorialWheelPickerProps) {
+  const scrollRef = useRef<ScrollView>(null);
+  const paddingVertical = ITEM_HEIGHT * Math.floor(VISIBLE_COUNT / 2);
+
+  useEffect(() => {
+    const index = values.indexOf(selected);
+    if (index < 0) return;
+
+    requestAnimationFrame(() => {
+      scrollRef.current?.scrollTo({ y: index * ITEM_HEIGHT, animated: false });
+    });
+  }, [selected, values]);
+
+  const handleScrollEnd = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const offsetY = event.nativeEvent.contentOffset.y;
+    const index = Math.min(
+      values.length - 1,
+      Math.max(0, Math.round(offsetY / ITEM_HEIGHT)),
+    );
+    onSelect(values[index]);
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.selectionHighlight} pointerEvents="none" />
+      <ScrollView
+        ref={scrollRef}
+        showsVerticalScrollIndicator={false}
+        snapToInterval={ITEM_HEIGHT}
+        decelerationRate="fast"
+        nestedScrollEnabled
+        onMomentumScrollEnd={handleScrollEnd}
+        onScrollEndDrag={handleScrollEnd}
+        contentContainerStyle={{ paddingVertical }}
+        style={styles.scroll}
+      >
+        {values.map((value) => {
+          const isSelected = value === selected;
+          return (
+            <View key={value} style={styles.item}>
+              <Text style={[styles.itemText, isSelected && styles.itemTextSelected]}>
+                {value}
+              </Text>
+            </View>
+          );
+        })}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: 56,
+    height: PICKER_HEIGHT,
+    overflow: 'hidden',
+  },
+  scroll: {
+    flex: 1,
+  },
+  selectionHighlight: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: ITEM_HEIGHT,
+    height: ITEM_HEIGHT,
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    borderColor: Palette.outlineVariant,
+  },
+  item: {
+    height: ITEM_HEIGHT,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  itemText: {
+    ...Typography.titleLg,
+    color: Palette.outline,
+  },
+  itemTextSelected: {
+    color: Palette.primary,
+  },
+});

--- a/components/onboarding/HeightPickerField.tsx
+++ b/components/onboarding/HeightPickerField.tsx
@@ -1,0 +1,69 @@
+import { useMemo } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { EditorialWheelPicker } from '@/components/onboarding/EditorialWheelPicker';
+import { Palette, Spacing, Typography } from '@/constants/design';
+
+const FEET_MIN = 3;
+const FEET_MAX = 8;
+const INCHES_MIN = 0;
+const INCHES_MAX = 11;
+
+type HeightPickerFieldProps = {
+  feet: number;
+  inches: number;
+  onFeetChange: (feet: number) => void;
+  onInchesChange: (inches: number) => void;
+};
+
+export function HeightPickerField({
+  feet,
+  inches,
+  onFeetChange,
+  onInchesChange,
+}: HeightPickerFieldProps) {
+  const feetValues = useMemo(
+    () => Array.from({ length: FEET_MAX - FEET_MIN + 1 }, (_, i) => FEET_MIN + i),
+    [],
+  );
+  const inchValues = useMemo(
+    () => Array.from({ length: INCHES_MAX - INCHES_MIN + 1 }, (_, i) => INCHES_MIN + i),
+    [],
+  );
+
+  return (
+    <View style={styles.fieldGroup}>
+      <Text style={styles.label}>Height</Text>
+      <View style={styles.pickerRow}>
+        <EditorialWheelPicker selected={feet} values={feetValues} onSelect={onFeetChange} />
+        <Text style={styles.unitLabel}>ft</Text>
+        <EditorialWheelPicker selected={inches} values={inchValues} onSelect={onInchesChange} />
+        <Text style={styles.unitLabel}>in</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  fieldGroup: {
+    gap: Spacing.stackSm,
+  },
+  label: {
+    ...Typography.labelSm,
+    color: Palette.onSurfaceVariant,
+    letterSpacing: 1.2,
+  },
+  pickerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderBottomWidth: 1,
+    borderBottomColor: Palette.outlineVariant,
+    paddingBottom: Spacing.stackSm,
+    gap: Spacing.stackSm,
+  },
+  unitLabel: {
+    ...Typography.titleLg,
+    color: Palette.onSurfaceVariant,
+    marginRight: Spacing.stackMd,
+  },
+});

--- a/components/ui/icon-symbol.tsx
+++ b/components/ui/icon-symbol.tsx
@@ -18,6 +18,8 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'chevron.left': 'arrow-back',
+  'arrow.forward': 'arrow-forward',
 } as IconMapping;
 
 /**

--- a/constants/design.ts
+++ b/constants/design.ts
@@ -1,0 +1,125 @@
+// Contains design constants for the app. Reference this for future screens.
+
+import { StyleSheet, type TextStyle } from 'react-native';
+
+export const Palette = {
+  onTertiary: '#ffffff',
+  tertiary: '#000000',
+  surfaceContainerHigh: '#e9e8e7',
+  onTertiaryFixedVariant: '#474745',
+  onSecondaryFixedVariant: '#32408c',
+  onPrimaryFixedVariant: '#474746',
+  surfaceContainerLow: '#f5f3f3',
+  secondary: '#4b58a5',
+  surfaceContainerLowest: '#ffffff',
+  onPrimary: '#ffffff',
+  inverseOnSurface: '#f2f0f0',
+  onBackground: '#1b1c1c',
+  errorContainer: '#ffdad6',
+  surfaceContainer: '#efeded',
+  background: '#fbf9f9',
+  secondaryFixed: '#dee0ff',
+  secondaryContainer: '#9dabfe',
+  onError: '#ffffff',
+  tertiaryFixedDim: '#c8c6c3',
+  secondaryFixedDim: '#bac3ff',
+  onErrorContainer: '#93000a',
+  onSecondaryFixed: '#00105b',
+  outline: '#747878',
+  primaryFixedDim: '#c8c6c5',
+  surfaceTint: '#5f5e5e',
+  surfaceVariant: '#e3e2e2',
+  onSecondaryContainer: '#2e3d88',
+  inversePrimary: '#c8c6c5',
+  surfaceContainerHighest: '#e3e2e2',
+  onSurfaceVariant: '#444748',
+  onPrimaryContainer: '#858383',
+  onSecondary: '#ffffff',
+  onTertiaryContainer: '#858481',
+  primaryContainer: '#1c1b1b',
+  inverseSurface: '#303031',
+  onPrimaryFixed: '#1c1b1b',
+  onSurface: '#1b1c1c',
+  outlineVariant: '#c4c7c7',
+  onTertiaryFixed: '#1c1c1a',
+  tertiaryContainer: '#1c1c1a',
+  surfaceDim: '#dbdad9',
+  surface: '#fbf9f9',
+  error: '#ba1a1a',
+  primaryFixed: '#e5e2e1',
+  tertiaryFixed: '#e5e2df',
+  primary: '#000000',
+  surfaceBright: '#fbf9f9',
+} as const;
+
+export const Spacing = {
+  stackSm: 8,
+  stackMd: 16,
+  stackLg: 32,
+  stackXl: 64,
+  containerMargin: 24,
+  gutter: 16,
+} as const;
+
+export const Radius = {
+  sm: 4,
+  md: 8,
+  lg: 12,
+  full: 9999,
+} as const;
+
+export const FontFamilies = {
+  body: 'Manrope_400Regular',
+  bodySemiBold: 'Manrope_600SemiBold',
+  display: 'Newsreader_500Medium',
+} as const;
+
+export const Typography = StyleSheet.create({
+  displayLg: {
+    fontFamily: FontFamilies.display,
+    fontSize: 40,
+    lineHeight: 44,
+    letterSpacing: -0.8,
+    fontWeight: '500',
+  },
+  headlineMd: {
+    fontFamily: FontFamilies.display,
+    fontSize: 28,
+    lineHeight: 34,
+    fontWeight: '500',
+  },
+  titleLg: {
+    fontFamily: FontFamilies.bodySemiBold,
+    fontSize: 20,
+    lineHeight: 28,
+    letterSpacing: 0.2,
+    fontWeight: '600',
+  },
+  bodyMd: {
+    fontFamily: FontFamilies.body,
+    fontSize: 16,
+    lineHeight: 26,
+    fontWeight: '400',
+  },
+  labelSm: {
+    fontFamily: FontFamilies.bodySemiBold,
+    fontSize: 12,
+    lineHeight: 12,
+    letterSpacing: 0.96,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+  },
+});
+
+export const textVariants = {
+  displayLg: Typography.displayLg as TextStyle,
+  headlineMd: Typography.headlineMd as TextStyle,
+  titleLg: Typography.titleLg as TextStyle,
+  bodyMd: Typography.bodyMd as TextStyle,
+  labelSm: Typography.labelSm as TextStyle,
+};
+
+export const LandingAssets = {
+  backgroundImage:
+    'https://lh3.googleusercontent.com/aida-public/AB6AXuBk3_CZIp6HpwH6QfgDjuFRRfDWEEBDHUNBrQh8DqxLsBnHW73pG1GXur0lrveraj9BOAQNlwWWwMCEFX8HNeQNZXDWJVfq-UO6mmnC59em4F05xdl12ujjYrzQKtuLU_aK_Zr841-VXChqhrZBKmjectiTh3UdeUsy8zckojqVU6WzW-oiAzcc4cp987SO8ODhjFL_Oj-_h490xMpraQIbfAr4_HxznJSC9_5G_NbEeIfUZVmw_PBCsmIueIJnfLOge9N53fAS-Ts',
+} as const;

--- a/lib/sign-up-draft.ts
+++ b/lib/sign-up-draft.ts
@@ -1,0 +1,19 @@
+// Saves email and password during onboarding process and clears after
+type SignUpDraft = {
+  email: string;
+  password: string;
+};
+
+let draft: SignUpDraft | null = null;
+
+export function setSignUpDraft(email: string, password: string) {
+  draft = { email, password };
+}
+
+export function getSignUpDraft(): SignUpDraft | null {
+  return draft;
+}
+
+export function clearSignUpDraft() {
+  draft = null;
+}

--- a/lib/sign-up.ts
+++ b/lib/sign-up.ts
@@ -1,0 +1,69 @@
+import { supabase } from '@/lib/supabase';
+import {
+  formatAuthError,
+  normalizeEmail,
+  validateAuthCredentials,
+  validateProfileForm,
+} from '@/lib/validation';
+
+export type SignUpProfileInput = {
+  email: string;
+  password: string;
+  name: string;
+  age: number;
+  heightInches: number;
+  gender: string;
+};
+
+export type SignUpResult =
+  | { ok: true; needsEmailConfirmation: boolean }
+  | { ok: false; message: string };
+
+export async function signUpWithProfile(input: SignUpProfileInput): Promise<SignUpResult> {
+  // Check email and password are valid
+  const credentialsError = validateAuthCredentials(input.email, input.password);
+  if (credentialsError) {
+    return { ok: false, message: credentialsError };
+  }
+
+  // Check name and age are valid
+  const profileValidationError = validateProfileForm({
+    fullName: input.name,
+    age: String(input.age),
+  });
+  if (profileValidationError) {
+    return { ok: false, message: profileValidationError };
+  }
+
+  // Sign up with Supabase Auth
+  const { data: authData, error: authError } = await supabase.auth.signUp({
+    email: normalizeEmail(input.email),
+    password: input.password,
+  });
+  if (authError) {
+    return { ok: false, message: formatAuthError(authError.message) };
+  }
+  const authUser = authData.user;
+  if (!authUser) {
+    return { ok: false, message: 'Account could not be created. Please try again.' };
+  }
+
+  // Add onboarding profile data to users table
+  const { error: insertError } = await supabase.from('users').insert({
+    id: authUser.id,
+    name: input.name.trim(),
+    age: input.age,
+    height: input.heightInches,
+    gender: input.gender,
+  });
+  if (insertError) {
+    return {
+      ok: false,
+      message: formatAuthError(insertError.message),
+    };
+  }
+
+  const needsEmailConfirmation = !authData.session;
+
+  return { ok: true, needsEmailConfirmation };
+}

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -1,0 +1,92 @@
+// Validation functions for basic error handling of form inputs 
+const EMAIL_REGEX =
+  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/;
+
+const MIN_PASSWORD_LENGTH = 6;
+const MIN_AGE = 10;
+const MAX_AGE = 100;
+
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export function isValidEmail(email: string): boolean {
+  const normalized = normalizeEmail(email);
+  if (!normalized || normalized.length > 254) {
+    return false;
+  }
+  return EMAIL_REGEX.test(normalized);
+}
+
+export function validateEmail(email: string): string | null {
+  const normalized = normalizeEmail(email);
+  if (!normalized) {
+    return 'Please enter your email address.';
+  }
+  if (!isValidEmail(normalized)) {
+    return 'Please enter a valid email address.';
+  }
+  return null;
+}
+
+export function validatePassword(password: string): string | null {
+  if (!password) {
+    return 'Please enter your password.';
+  }
+  if (password.length < MIN_PASSWORD_LENGTH) {
+    return `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`;
+  }
+  return null;
+}
+
+export function validateAuthCredentials(
+  email: string,
+  password: string,
+): string | null {
+  return validateEmail(email) ?? validatePassword(password);
+}
+
+export type ProfileFormInput = {
+  fullName: string;
+  age: string;
+};
+
+export function validateProfileForm(input: ProfileFormInput): string | null {
+  const trimmedName = input.fullName.trim();
+  if (!trimmedName) {
+    return 'Please enter your full name.';
+  }
+
+  if (!input.age.trim()) {
+    return 'Please enter your age.';
+  }
+
+  const parsedAge = Number.parseInt(input.age, 10);
+  if (Number.isNaN(parsedAge) || parsedAge < MIN_AGE || parsedAge > MAX_AGE) {
+    return `Please enter a valid age (${MIN_AGE}–${MAX_AGE}).`;
+  }
+
+  return null;
+}
+
+export function formatAuthError(message: string): string {
+  const lower = message.toLowerCase();
+
+  if (lower.includes('rate limit')) {
+    return 'Too many sign-up attempts. Please wait a while and try again.';
+  }
+
+  if (lower.includes('already registered') || lower.includes('already been registered')) {
+    return 'An account with this email already exists. Try signing in instead.';
+  }
+
+  if (lower.includes('invalid') && lower.includes('email')) {
+    return 'This email address is not accepted. Try a longer Gmail address (e.g. name@gmail.com) or another provider.';
+  }
+
+  if (lower.includes('password')) {
+    return message;
+  }
+
+  return message;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "fitted",
       "version": "1.0.0",
       "dependencies": {
+        "@expo-google-fonts/manrope": "^0.4.2",
+        "@expo-google-fonts/newsreader": "^0.4.1",
         "@expo/vector-icons": "^15.0.3",
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
@@ -1744,6 +1746,18 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@expo-google-fonts/manrope": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/manrope/-/manrope-0.4.2.tgz",
+      "integrity": "sha512-BZsKe8d9BJrVnIQIZcTS7/Kac0TbXnqs/+8EBSiQxrmK6GoCO6eTkmr50D1weIk/EoF20pTmAkpWICnovATr/g==",
+      "license": "MIT AND OFL-1.1"
+    },
+    "node_modules/@expo-google-fonts/newsreader": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/newsreader/-/newsreader-0.4.1.tgz",
+      "integrity": "sha512-j96W112+mj/VYP06DCq00w+twyw42w0MY7eHB/XXioNK80BcG0cIk/zogjOENZSY7qejzIFbHE/PZYqlh/6VKQ==",
+      "license": "MIT AND OFL-1.1"
     },
     "node_modules/@expo/code-signing-certificates": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "lint": "expo lint"
   },
   "dependencies": {
+    "@expo-google-fonts/manrope": "^0.4.2",
+    "@expo-google-fonts/newsreader": "^0.4.1",
     "@expo/vector-icons": "^15.0.3",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",


### PR DESCRIPTION
Closes Issue: #2 

**Done:** 
- Created "Login" and "Create Account" flow screens. 
- Upon "Create Account", it redirects to a new onboarding screen with inputs for name, age, height, gender. 
- Upon submit, it creates an account with Supabase Auth as well as insert onboarding information to the "user" table. 
- Basic error handling for invalid credentials and missing fields (eg. emails, passwords, name, age, height, gender choices)
- Account Creation was slightly buggy with issue of duplicate keys since Supabase had a function and trigger that handled new users being created. I deleted the Supabase function and wrote it in code instead. 

**Not Done:** 
- Does not navigate to the Avatar page but rather a blank placeholder screen. (app/home.tsx)

**AI Usage:** 
- I used AI to help solidify the UI and the styling sheets but fixed it up myself during testing and validation. 
- I also used AI to generate the placeholder screen in app/home.tsx as we will be overwriting it with a correct screen.

**Images:** 
<img width="360" height="730" alt="Screenshot 2026-05-28 at 9 36 23 PM" src="https://github.com/user-attachments/assets/428fd4bb-f63d-4e17-bb1a-5144f77e9726" />
<img width="357" height="721" alt="Screenshot 2026-05-28 at 9 36 57 PM" src="https://github.com/user-attachments/assets/09446cd4-0df8-4ae8-a66d-b446160c61a9" />