### PR TITLE
Avatar creation + Backend Schema Change

### DIFF
--- a/client/app/(main)/_layout.tsx
+++ b/client/app/(main)/_layout.tsx
@@ -1,9 +1,12 @@
-import { BottomTabBarProps } from '@react-navigation/bottom-tabs';
-import { Tabs } from 'expo-router';
-import { StyleSheet, View } from 'react-native';
+import { BottomTabBarProps } from "@react-navigation/bottom-tabs";
+import { Tabs } from "expo-router";
+import { StyleSheet, View } from "react-native";
 
-import { BottomNavBar, type BottomNavTab } from '@/components/ui/bottom-nav-bar';
-import { Palette } from '@/constants/design';
+import {
+  BottomNavBar,
+  type BottomNavTab,
+} from "@/components/ui/bottom-nav-bar";
+import { Palette } from "@/constants/design";
 
 function MainTabBar({ state, navigation }: BottomTabBarProps) {
   const activeTab = state.routes[state.index].name as BottomNavTab;
@@ -12,10 +15,10 @@ function MainTabBar({ state, navigation }: BottomTabBarProps) {
     <BottomNavBar
       activeTab={activeTab}
       onTabPress={(tab) => {
-        if (tab === 'upload') {
+        if (tab === "upload") {
           navigation.reset({
             index: 0,
-            routes: [{ name: 'upload' }],
+            routes: [{ name: "upload" }],
           });
           return;
         }
@@ -36,13 +39,15 @@ export default function MainLayout() {
         tabBar={(props) => <MainTabBar {...props} />}
         screenOptions={{
           headerShown: false,
-          animation: 'none',
-        }}>
-        <Tabs.Screen name="closet" options={{ title: 'My Closet' }} />
-        <Tabs.Screen name="collections" options={{ title: 'Collections' }} />
-        <Tabs.Screen name="upload" options={{ title: 'Upload' }} />
-        <Tabs.Screen name="calendar" options={{ title: 'Calendar' }} />
-        <Tabs.Screen name="profile" options={{ title: 'Profile' }} />
+          animation: "none",
+        }}
+      >
+        <Tabs.Screen name="closet" options={{ title: "My Closet" }} />
+        <Tabs.Screen name="collections" options={{ title: "Collections" }} />
+        <Tabs.Screen name="upload" options={{ title: "Upload" }} />
+        <Tabs.Screen name="avatar" options={{ title: "Avatar" }} />
+        <Tabs.Screen name="calendar" options={{ title: "Calendar" }} />
+        <Tabs.Screen name="profile" options={{ title: "Profile" }} />
       </Tabs>
     </View>
   );

--- a/client/app/(main)/avatar.tsx
+++ b/client/app/(main)/avatar.tsx
@@ -24,9 +24,9 @@ export default function AvatarScreen() {
   const [items, setItems] = useState<any[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [selectedItemIds, setSelectedItemIds] = useState<Set<string>>(
-    new Set(),
-  );
+  const [selectedItemIds, setSelectedItemIds] = useState<
+    Record<string, string>
+  >({});
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
@@ -57,20 +57,60 @@ export default function AvatarScreen() {
       });
   }, [user]);
 
-  const toggleItemSelection = (itemId: string) => {
+  const toggleItemSelection = (itemId: string, category: string) => {
     setSelectedItemIds((prev) => {
-      const updated = new Set(prev);
-      if (updated.has(itemId)) {
-        updated.delete(itemId);
-      } else {
-        updated.add(itemId);
+      if (prev[category] === itemId) {
+        const { [category]: _, ...rest } = prev;
+        return rest;
       }
-      return updated;
+
+      return {
+        ...prev,
+        [category]: itemId,
+      };
     });
   };
 
   const saveOutfit = async () => {
-    console.log("Saving outfit with item IDs:", Array.from(selectedItemIds));
+    if (!user || Object.keys(selectedItemIds).length !== SECTIONS.length)
+      return;
+
+    setSaving(true);
+    try {
+      // Create outfit
+      const { data: outfitData, error: outfitError } = await supabase
+        .from("outfits")
+        .insert([{ user_id: user.id }])
+        .select();
+
+      if (outfitError) throw outfitError;
+
+      const outfitId = outfitData?.[0]?.id;
+      if (!outfitId) throw new Error("Failed to create outfit");
+
+      // Create outfit items with slot metadata
+      const outfitItems = Object.entries(selectedItemIds).map(
+        ([category, itemId]) => ({
+          outfit_id: outfitId,
+          item_id: itemId,
+          slot: category,
+        }),
+      );
+
+      const { error: itemsError } = await supabase
+        .from("outfit_items")
+        .insert(outfitItems);
+
+      if (itemsError) throw itemsError;
+
+      // Reset selection
+      setSelectedItemIds({});
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save outfit");
+    } finally {
+      setSaving(false);
+    }
   };
 
   return (
@@ -112,10 +152,12 @@ export default function AvatarScreen() {
                       sectionItems.map((item) => (
                         <Pressable
                           key={item.id}
-                          onPress={() => toggleItemSelection(item.id)}
+                          onPress={() =>
+                            toggleItemSelection(item.id, item.category)
+                          }
                           style={[
                             styles.cardWrapper,
-                            selectedItemIds.has(item.id) &&
+                            selectedItemIds[item.category] === item.id &&
                               styles.cardWrapperSelected,
                           ]}
                         >
@@ -145,11 +187,17 @@ export default function AvatarScreen() {
               <Pressable
                 style={[
                   styles.submitButton,
-                  (!user || selectedItemIds.size === 0 || saving) &&
+                  (!user ||
+                    Object.keys(selectedItemIds).length !== SECTIONS.length ||
+                    saving) &&
                     styles.submitButtonDisabled,
                 ]}
                 onPress={saveOutfit}
-                disabled={!user || selectedItemIds.size === 0 || saving}
+                disabled={
+                  !user ||
+                  Object.keys(selectedItemIds).length !== SECTIONS.length ||
+                  saving
+                }
               >
                 <Text style={styles.submitButtonText}>
                   {saving ? "Saving..." : "Save Outfit"}

--- a/client/app/(main)/avatar.tsx
+++ b/client/app/(main)/avatar.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import {
   ActivityIndicator,
+  Pressable,
   ScrollView,
   StyleSheet,
   Text,
@@ -23,6 +24,10 @@ export default function AvatarScreen() {
   const [items, setItems] = useState<any[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [selectedItemIds, setSelectedItemIds] = useState<Set<string>>(
+    new Set(),
+  );
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     supabase.auth.getUser().then(({ data }) => {
@@ -51,6 +56,22 @@ export default function AvatarScreen() {
         setLoading(false);
       });
   }, [user]);
+
+  const toggleItemSelection = (itemId: string) => {
+    setSelectedItemIds((prev) => {
+      const updated = new Set(prev);
+      if (updated.has(itemId)) {
+        updated.delete(itemId);
+      } else {
+        updated.add(itemId);
+      }
+      return updated;
+    });
+  };
+
+  const saveOutfit = async () => {
+    console.log("Saving outfit with item IDs:", Array.from(selectedItemIds));
+  };
 
   return (
     <SafeAreaView style={styles.safeArea} edges={["top", "left", "right"]}>
@@ -89,15 +110,24 @@ export default function AvatarScreen() {
                   >
                     {sectionItems.length > 0 ? (
                       sectionItems.map((item) => (
-                        <ClosetItemCard
+                        <Pressable
                           key={item.id}
-                          id={item.id}
-                          name={item.name}
-                          category={item.category}
-                          subcategory={item.subcategory}
-                          imageUrl={item.image_url}
-                          style={styles.horizontalCard}
-                        />
+                          onPress={() => toggleItemSelection(item.id)}
+                          style={[
+                            styles.cardWrapper,
+                            selectedItemIds.has(item.id) &&
+                              styles.cardWrapperSelected,
+                          ]}
+                        >
+                          <ClosetItemCard
+                            id={item.id}
+                            name={item.name}
+                            category={item.category}
+                            subcategory={item.subcategory}
+                            imageUrl={item.image_url}
+                            style={styles.horizontalCard}
+                          />
+                        </Pressable>
                       ))
                     ) : (
                       <View style={styles.emptySection}>
@@ -110,6 +140,22 @@ export default function AvatarScreen() {
                 </View>
               );
             })}
+
+            <View style={styles.submitContainer}>
+              <Pressable
+                style={[
+                  styles.submitButton,
+                  (!user || selectedItemIds.size === 0 || saving) &&
+                    styles.submitButtonDisabled,
+                ]}
+                onPress={saveOutfit}
+                disabled={!user || selectedItemIds.size === 0 || saving}
+              >
+                <Text style={styles.submitButtonText}>
+                  {saving ? "Saving..." : "Save Outfit"}
+                </Text>
+              </Pressable>
+            </View>
           </ScrollView>
         )}
       </View>
@@ -171,5 +217,34 @@ const styles = StyleSheet.create({
   emptyText: {
     ...Typography.bodyMd,
     color: Palette.onSurfaceVariant,
+  },
+  cardWrapper: {
+    marginRight: Spacing.stackMd,
+  },
+  cardWrapperSelected: {
+    opacity: 0.6,
+    borderRadius: 8,
+    borderWidth: 2,
+    borderColor: Palette.primary,
+  },
+  submitContainer: {
+    marginTop: Spacing.stackLg,
+    paddingVertical: Spacing.stackMd,
+  },
+  submitButton: {
+    backgroundColor: Palette.primary,
+    paddingVertical: Spacing.stackMd,
+    paddingHorizontal: Spacing.containerMargin,
+    borderRadius: 8,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  submitButtonDisabled: {
+    backgroundColor: Palette.surfaceContainerHigh,
+    opacity: 0.5,
+  },
+  submitButtonText: {
+    ...Typography.titleLg,
+    color: Palette.onPrimary,
   },
 });

--- a/client/app/(main)/avatar.tsx
+++ b/client/app/(main)/avatar.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import { Palette, Spacing, Typography } from "@/constants/design";
+
+export default function AvatarScreen() {
+  return (
+    <SafeAreaView style={styles.safeArea} edges={["top", "left", "right"]}>
+      <View style={styles.screen}>
+        <Text style={styles.title}>Avatar Creator</Text>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: Palette.background,
+  },
+  screen: {
+    flex: 1,
+    backgroundColor: Palette.background,
+    paddingHorizontal: Spacing.containerMargin,
+    paddingTop: Spacing.containerMargin,
+  },
+  title: {
+    ...Typography.headlineMd,
+    color: Palette.onSurface,
+    marginBottom: Spacing.stackMd,
+  },
+});

--- a/client/app/(main)/avatar.tsx
+++ b/client/app/(main)/avatar.tsx
@@ -10,14 +10,21 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { ClosetItemCard } from "@/components/closet/ClosetItemCard";
+import { Category } from "@/constants/categories";
 import { Palette, Spacing, Typography } from "@/constants/design";
 import { supabase } from "@/lib/supabase";
 
 const SECTIONS = [
-  { title: "Tops", category: "tops" },
-  { title: "Bottoms", category: "bottoms" },
-  { title: "Shoes", category: "shoes" },
+  { title: "Tops", category: Category.Tops },
+  { title: "Bottoms", category: Category.Bottoms },
+  { title: "Shoes", category: Category.Shoes },
 ] as const;
+
+const CATEGORY_SLOT_MAP: Partial<Record<Category, string>> = {
+  [Category.Tops]: "top",
+  [Category.Bottoms]: "bottom",
+  [Category.Shoes]: "footwear",
+};
 
 export default function AvatarScreen() {
   const [user, setUser] = useState<any>(null);
@@ -25,7 +32,7 @@ export default function AvatarScreen() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedItemIds, setSelectedItemIds] = useState<
-    Record<string, string>
+    Partial<Record<Category, string>>
   >({});
   const [saving, setSaving] = useState(false);
 
@@ -57,7 +64,7 @@ export default function AvatarScreen() {
       });
   }, [user]);
 
-  const toggleItemSelection = (itemId: string, category: string) => {
+  const toggleItemSelection = (itemId: string, category: Category) => {
     setSelectedItemIds((prev) => {
       if (prev[category] === itemId) {
         const { [category]: _, ...rest } = prev;
@@ -93,7 +100,7 @@ export default function AvatarScreen() {
         ([category, itemId]) => ({
           outfit_id: outfitId,
           item_id: itemId,
-          slot: category,
+          slot: CATEGORY_SLOT_MAP[category as Category],
         }),
       );
 
@@ -153,12 +160,15 @@ export default function AvatarScreen() {
                         <Pressable
                           key={item.id}
                           onPress={() =>
-                            toggleItemSelection(item.id, item.category)
+                            toggleItemSelection(
+                              item.id,
+                              item.category as Category,
+                            )
                           }
                           style={[
                             styles.cardWrapper,
-                            selectedItemIds[item.category] === item.id &&
-                              styles.cardWrapperSelected,
+                            selectedItemIds[item.category as Category] ===
+                              item.id && styles.cardWrapperSelected,
                           ]}
                         >
                           <ClosetItemCard

--- a/client/app/(main)/avatar.tsx
+++ b/client/app/(main)/avatar.tsx
@@ -1,14 +1,117 @@
-import React from "react";
-import { StyleSheet, Text, View } from "react-native";
+import React, { useEffect, useState } from "react";
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
+import { ClosetItemCard } from "@/components/closet/ClosetItemCard";
 import { Palette, Spacing, Typography } from "@/constants/design";
+import { supabase } from "@/lib/supabase";
+
+const SECTIONS = [
+  { title: "Tops", category: "tops" },
+  { title: "Bottoms", category: "bottoms" },
+  { title: "Shoes", category: "shoes" },
+] as const;
 
 export default function AvatarScreen() {
+  const [user, setUser] = useState<any>(null);
+  const [items, setItems] = useState<any[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      if (data?.user) {
+        setUser(data.user);
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!user) return;
+
+    setLoading(true);
+    supabase
+      .from("items")
+      .select("*")
+      .eq("user_id", user.id)
+      .then(({ data, error }) => {
+        if (error) {
+          setError(error.message);
+          setItems([]);
+        } else {
+          setItems(data || []);
+          setError(null);
+        }
+        setLoading(false);
+      });
+  }, [user]);
+
   return (
     <SafeAreaView style={styles.safeArea} edges={["top", "left", "right"]}>
       <View style={styles.screen}>
         <Text style={styles.title}>Avatar Creator</Text>
+
+        {loading ? (
+          <ActivityIndicator
+            color={Palette.primary}
+            size="large"
+            style={styles.loader}
+          />
+        ) : error ? (
+          <Text style={styles.errorText}>{error}</Text>
+        ) : !user ? (
+          <Text style={styles.messageText}>
+            Please sign in to view your closet items.
+          </Text>
+        ) : (
+          <ScrollView
+            showsVerticalScrollIndicator={false}
+            contentContainerStyle={styles.scrollContent}
+          >
+            {SECTIONS.map((section) => {
+              const sectionItems = items.filter(
+                (item) => item.category === section.category,
+              );
+
+              return (
+                <View key={section.category} style={styles.section}>
+                  <Text style={styles.sectionTitle}>{section.title}</Text>
+                  <ScrollView
+                    horizontal
+                    showsHorizontalScrollIndicator={false}
+                    contentContainerStyle={styles.sectionList}
+                  >
+                    {sectionItems.length > 0 ? (
+                      sectionItems.map((item) => (
+                        <ClosetItemCard
+                          key={item.id}
+                          id={item.id}
+                          name={item.name}
+                          category={item.category}
+                          subcategory={item.subcategory}
+                          imageUrl={item.image_url}
+                          style={styles.horizontalCard}
+                        />
+                      ))
+                    ) : (
+                      <View style={styles.emptySection}>
+                        <Text style={styles.emptyText}>
+                          No {section.title.toLowerCase()} in your closet yet.
+                        </Text>
+                      </View>
+                    )}
+                  </ScrollView>
+                </View>
+              );
+            })}
+          </ScrollView>
+        )}
       </View>
     </SafeAreaView>
   );
@@ -29,5 +132,44 @@ const styles = StyleSheet.create({
     ...Typography.headlineMd,
     color: Palette.onSurface,
     marginBottom: Spacing.stackMd,
+  },
+  loader: {
+    marginTop: Spacing.stackLg,
+  },
+  errorText: {
+    ...Typography.bodyMd,
+    color: Palette.error,
+    marginTop: Spacing.stackMd,
+  },
+  messageText: {
+    ...Typography.bodyMd,
+    color: Palette.onSurfaceVariant,
+    marginTop: Spacing.stackMd,
+  },
+  scrollContent: {
+    paddingBottom: Spacing.stackXl,
+  },
+  section: {
+    marginBottom: Spacing.stackLg,
+  },
+  sectionTitle: {
+    ...Typography.titleLg,
+    color: Palette.onSurface,
+    marginBottom: Spacing.stackMd,
+  },
+  sectionList: {
+    paddingRight: Spacing.containerMargin,
+  },
+  horizontalCard: {
+    width: 180,
+    marginRight: Spacing.stackMd,
+  },
+  emptySection: {
+    minHeight: 240,
+    justifyContent: "center",
+  },
+  emptyText: {
+    ...Typography.bodyMd,
+    color: Palette.onSurfaceVariant,
   },
 });

--- a/client/app/(main)/closet.tsx
+++ b/client/app/(main)/closet.tsx
@@ -1,7 +1,14 @@
 import React, { useEffect, useState } from "react";
-import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
+import { ClosetItemCard } from "@/components/closet/ClosetItemCard";
 import { Palette, Spacing, Typography } from "@/constants/design";
 import { supabase } from "@/lib/supabase";
 
@@ -45,22 +52,36 @@ export default function ClosetScreen() {
         <Text style={styles.title}>My Closet</Text>
 
         {loading ? (
-          <ActivityIndicator color={Palette.primary} />
+          <ActivityIndicator
+            color={Palette.primary}
+            size="large"
+            style={styles.loader}
+          />
         ) : error ? (
-          <Text>{error}</Text>
+          <Text style={styles.errorText}>{error}</Text>
         ) : !user ? (
-          <Text>Please sign in to view your closet.</Text>
+          <Text style={styles.messageText}>
+            Please sign in to view your closet.
+          </Text>
         ) : items.length === 0 ? (
-          <Text>No items found in your closet yet.</Text>
+          <Text style={styles.messageText}>
+            No items found in your closet yet.
+          </Text>
         ) : (
-          <View>
+          <ScrollView
+            showsVerticalScrollIndicator={false}
+            contentContainerStyle={styles.listContent}
+          >
             {items.map((item) => (
-              <View key={item.id}>
-                <Text>{item.category ?? "Unnamed item"}</Text>
-                <Text>ID: {item.id}</Text>
-              </View>
+              <ClosetItemCard
+                key={item.id}
+                id={item.id}
+                name={item.name}
+                category={item.category}
+                imageUrl={item.image_url}
+              />
             ))}
-          </View>
+          </ScrollView>
         )}
       </View>
     </SafeAreaView>
@@ -81,5 +102,22 @@ const styles = StyleSheet.create({
   title: {
     ...Typography.headlineMd,
     color: Palette.onSurface,
+    marginBottom: Spacing.stackMd,
+  },
+  loader: {
+    marginTop: Spacing.stackLg,
+  },
+  errorText: {
+    ...Typography.bodyMd,
+    color: Palette.error,
+    marginTop: Spacing.stackMd,
+  },
+  messageText: {
+    ...Typography.bodyMd,
+    color: Palette.onSurfaceVariant,
+    marginTop: Spacing.stackMd,
+  },
+  listContent: {
+    paddingBottom: Spacing.stackXl,
   },
 });

--- a/client/app/(main)/closet.tsx
+++ b/client/app/(main)/closet.tsx
@@ -1,13 +1,67 @@
-import { StyleSheet, Text, View } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import React, { useEffect, useState } from "react";
+import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
-import { Palette, Spacing, Typography } from '@/constants/design';
+import { Palette, Spacing, Typography } from "@/constants/design";
+import { supabase } from "@/lib/supabase";
 
 export default function ClosetScreen() {
+  const [user, setUser] = useState<any>(null);
+  const [items, setItems] = useState<any[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      if (data?.user) {
+        setUser(data.user);
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!user) return;
+
+    setLoading(true);
+    supabase
+      .from("items")
+      .select("*")
+      .eq("user_id", user.id)
+      .then(({ data, error }) => {
+        if (error) {
+          setError(error.message);
+          setItems([]);
+        } else {
+          setItems(data || []);
+          setError(null);
+        }
+        setLoading(false);
+      });
+  }, [user]);
+
   return (
-    <SafeAreaView style={styles.safeArea} edges={['top', 'left', 'right']}>
+    <SafeAreaView style={styles.safeArea} edges={["top", "left", "right"]}>
       <View style={styles.screen}>
         <Text style={styles.title}>My Closet</Text>
+
+        {loading ? (
+          <ActivityIndicator color={Palette.primary} />
+        ) : error ? (
+          <Text>{error}</Text>
+        ) : !user ? (
+          <Text>Please sign in to view your closet.</Text>
+        ) : items.length === 0 ? (
+          <Text>No items found in your closet yet.</Text>
+        ) : (
+          <View>
+            {items.map((item) => (
+              <View key={item.id}>
+                <Text>{item.category ?? "Unnamed item"}</Text>
+                <Text>ID: {item.id}</Text>
+              </View>
+            ))}
+          </View>
+        )}
       </View>
     </SafeAreaView>
   );

--- a/client/app/(main)/closet.tsx
+++ b/client/app/(main)/closet.tsx
@@ -78,6 +78,7 @@ export default function ClosetScreen() {
                 id={item.id}
                 name={item.name}
                 category={item.category}
+                subcategory={item.subcategory}
                 imageUrl={item.image_url}
               />
             ))}

--- a/client/app/_layout.tsx
+++ b/client/app/_layout.tsx
@@ -2,22 +2,26 @@ import {
   Manrope_400Regular,
   Manrope_600SemiBold,
   useFonts as useManropeFonts,
-} from '@expo-google-fonts/manrope';
+} from "@expo-google-fonts/manrope";
 import {
   Newsreader_500Medium,
   useFonts as useNewsreaderFonts,
-} from '@expo-google-fonts/newsreader';
-import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
-import { Stack } from 'expo-router';
-import * as SplashScreen from 'expo-splash-screen';
-import { StatusBar } from 'expo-status-bar';
-import { useEffect } from 'react';
-import 'react-native-reanimated';
+} from "@expo-google-fonts/newsreader";
+import {
+  DarkTheme,
+  DefaultTheme,
+  ThemeProvider,
+} from "@react-navigation/native";
+import { Stack } from "expo-router";
+import * as SplashScreen from "expo-splash-screen";
+import { StatusBar } from "expo-status-bar";
+import { useEffect } from "react";
+import "react-native-reanimated";
 
-import { useColorScheme } from '@/hooks/use-color-scheme';
+import { useColorScheme } from "@/hooks/use-color-scheme";
 
 export const unstable_settings = {
-  anchor: '(tabs)',
+  anchor: "(tabs)",
 };
 
 SplashScreen.preventAutoHideAsync();
@@ -43,15 +47,18 @@ export default function RootLayout() {
   }
 
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+    <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen
           name="onboarding/personal-info"
-          options={{ headerShown: false, presentation: 'card' }}
+          options={{ headerShown: false, presentation: "card" }}
         />
         <Stack.Screen name="(main)" options={{ headerShown: false }} />
-        <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
+        <Stack.Screen
+          name="modal"
+          options={{ presentation: "modal", title: "Modal" }}
+        />
       </Stack>
       <StatusBar style="auto" />
     </ThemeProvider>

--- a/client/components/closet/ClosetItemCard.tsx
+++ b/client/components/closet/ClosetItemCard.tsx
@@ -1,0 +1,73 @@
+import { Image } from "expo-image";
+import { StyleSheet, Text, View } from "react-native";
+
+import { Palette, Radius, Spacing, Typography } from "@/constants/design";
+
+type ClosetItemCardProps = {
+  id: string;
+  name?: string;
+  category?: string;
+  imageUrl?: string;
+};
+
+export function ClosetItemCard({
+  id,
+  name,
+  category,
+  imageUrl,
+}: ClosetItemCardProps) {
+  const displayName = name || category || "Unnamed item";
+
+  return (
+    <View style={styles.card}>
+      {imageUrl ? (
+        <Image
+          source={{ uri: imageUrl }}
+          style={styles.image}
+          contentFit="cover"
+        />
+      ) : (
+        <View style={styles.imagePlaceholder}>
+          <Text style={styles.placeholderText}>No image</Text>
+        </View>
+      )}
+      <View style={styles.content}>
+        <Text style={styles.title} numberOfLines={2}>
+          {displayName}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: Palette.surfaceContainerLowest,
+    borderRadius: Radius.md,
+    overflow: "hidden",
+    marginBottom: Spacing.stackMd,
+  },
+  image: {
+    width: "100%",
+    height: 200,
+    backgroundColor: Palette.surfaceContainerHigh,
+  },
+  imagePlaceholder: {
+    width: "100%",
+    height: 200,
+    backgroundColor: Palette.surfaceContainerHigh,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  placeholderText: {
+    ...Typography.bodyMd,
+    color: Palette.onSurfaceVariant,
+  },
+  content: {
+    padding: Spacing.stackMd,
+  },
+  title: {
+    ...Typography.titleLg,
+    color: Palette.onSurface,
+  },
+});

--- a/client/components/closet/ClosetItemCard.tsx
+++ b/client/components/closet/ClosetItemCard.tsx
@@ -1,5 +1,11 @@
 import { Image } from "expo-image";
-import { StyleSheet, Text, View } from "react-native";
+import {
+  StyleSheet,
+  Text,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from "react-native";
 
 import { Palette, Radius, Spacing, Typography } from "@/constants/design";
 
@@ -7,19 +13,23 @@ type ClosetItemCardProps = {
   id: string;
   name?: string;
   category?: string;
+  subcategory?: string;
   imageUrl?: string;
+  style?: StyleProp<ViewStyle>;
 };
 
 export function ClosetItemCard({
   id,
   name,
   category,
+  subcategory,
   imageUrl,
+  style,
 }: ClosetItemCardProps) {
-  const displayName = name || category || "Unnamed item";
+  const displayName = name || subcategory || category || "Unnamed item";
 
   return (
-    <View style={styles.card}>
+    <View style={[styles.card, style]}>
       {imageUrl ? (
         <Image
           source={{ uri: imageUrl }}

--- a/client/components/ui/bottom-nav-bar.tsx
+++ b/client/components/ui/bottom-nav-bar.tsx
@@ -1,30 +1,37 @@
-import MaterialIcons from '@expo/vector-icons/MaterialIcons';
-import { ComponentProps } from 'react';
-import { Pressable, StyleSheet, View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import MaterialIcons from "@expo/vector-icons/MaterialIcons";
+import { ComponentProps } from "react";
+import { Pressable, StyleSheet, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-import { Palette, Spacing } from '@/constants/design';
+import { Palette, Spacing } from "@/constants/design";
 
 // Bottom navigation bar items
-export type BottomNavTab = 'closet' | 'collections' | 'upload' | 'calendar' | 'profile';
+export type BottomNavTab =
+  | "closet"
+  | "collections"
+  | "upload"
+  | "calendar"
+  | "avatar"
+  | "profile";
 // Bottom navigation bar as a whole knows which one is active and what to do when a tab is pressed
 export type BottomNavBarProps = {
   activeTab: BottomNavTab;
   onTabPress: (tab: BottomNavTab) => void;
 };
 
-type MaterialIconName = ComponentProps<typeof MaterialIcons>['name'];
+type MaterialIconName = ComponentProps<typeof MaterialIcons>["name"];
 type NavItemConfig = {
   id: BottomNavTab;
   label: string;
   icon: MaterialIconName;
 };
 const NAV_ITEMS: NavItemConfig[] = [
-  { id: 'closet', label: 'My Closet', icon: 'checkroom' },
-  { id: 'collections', label: 'Collections', icon: 'accessibility' },
-  { id: 'upload', label: 'Upload', icon: 'add-circle' },
-  { id: 'calendar', label: 'Calendar', icon: 'calendar-month' },
-  { id: 'profile', label: 'Profile', icon: 'person' },
+  { id: "closet", label: "My Closet", icon: "checkroom" },
+  { id: "collections", label: "Collections", icon: "accessibility" },
+  { id: "upload", label: "Upload", icon: "add-circle" },
+  { id: "avatar", label: "Avatar", icon: "face" },
+  { id: "calendar", label: "Calendar", icon: "calendar-month" },
+  { id: "profile", label: "Profile", icon: "person" },
 ];
 
 const ICON_SIZE = 24;
@@ -49,7 +56,8 @@ function NavItem({ item, isActive, onPress }: NavItemProps) {
         styles.navItem,
         isActive && styles.navItemActive,
         pressed && styles.navItemPressed,
-      ]}>
+      ]}
+    >
       <MaterialIcons
         name={item.icon}
         size={isActive ? ICON_SIZE + 2 : ICON_SIZE}
@@ -63,7 +71,12 @@ export function BottomNavBar({ activeTab, onTabPress }: BottomNavBarProps) {
   const { bottom } = useSafeAreaInsets();
 
   return (
-    <View style={[styles.container, { paddingBottom: Math.max(bottom, Spacing.stackMd) }]}>
+    <View
+      style={[
+        styles.container,
+        { paddingBottom: Math.max(bottom, Spacing.stackMd) },
+      ]}
+    >
       {NAV_ITEMS.map((item) => (
         <NavItem
           key={item.id}
@@ -78,25 +91,25 @@ export function BottomNavBar({ activeTab, onTabPress }: BottomNavBarProps) {
 
 const styles = StyleSheet.create({
   container: {
-    position: 'absolute',
+    position: "absolute",
     bottom: 0,
     left: 0,
     right: 0,
-    flexDirection: 'row',
-    justifyContent: 'space-around',
-    alignItems: 'center',
+    flexDirection: "row",
+    justifyContent: "space-around",
+    alignItems: "center",
     paddingTop: Spacing.stackMd,
     paddingHorizontal: Spacing.containerMargin,
     backgroundColor: Palette.surfaceContainerLowest,
-    shadowColor: '#000000',
+    shadowColor: "#000000",
     shadowOffset: { width: 0, height: -4 },
     shadowOpacity: 0.04,
     shadowRadius: 24,
     elevation: 8,
   },
   navItem: {
-    alignItems: 'center',
-    justifyContent: 'center',
+    alignItems: "center",
+    justifyContent: "center",
     transform: [{ scale: 1 }],
   },
   navItemActive: {

--- a/client/constants/categories.ts
+++ b/client/constants/categories.ts
@@ -1,15 +1,15 @@
 export enum Category {
-  Outerwear = 'Outerwear',
-  Tops = 'Tops',
-  Bottoms = 'Bottoms',
-  Shoes = 'Shoes',
-  Accessories = 'Accessories',
+  Outerwear = "Outerwear",
+  Tops = "Tops",
+  Bottoms = "Bottoms",
+  Shoes = "Shoes",
+  Accessories = "Accessories",
 }
 
 export const SUBCATEGORIES: Record<Category, string[]> = {
-  [Category.Outerwear]: ['Hoodie', 'Zip-up', 'Coat', 'Jacket'],
-  [Category.Tops]:      ['T-Shirt', 'Shirt', 'Sweater', 'Tank Top'],
-  [Category.Bottoms]:   ['Jeans', 'Trousers', 'Shorts', 'Skirt'],
-  [Category.Shoes]:     ['Sneakers', 'Boots', 'Loafers', 'Sandals'],
-  [Category.Accessories]: ['Coming Soon'],
+  [Category.Outerwear]: ["Hoodie", "Zip-up", "Coat", "Jacket"],
+  [Category.Tops]: ["T-Shirt", "Shirt", "Sweater", "Tank Top"],
+  [Category.Bottoms]: ["Jeans", "Trousers", "Shorts", "Skirt"],
+  [Category.Shoes]: ["Sneakers", "Boots", "Loafers", "Sandals"],
+  [Category.Accessories]: ["Coming Soon"],
 };

--- a/client/constants/categories.ts
+++ b/client/constants/categories.ts
@@ -1,9 +1,9 @@
 export enum Category {
-  Outerwear = "Outerwear",
-  Tops = "Tops",
-  Bottoms = "Bottoms",
-  Shoes = "Shoes",
-  Accessories = "Accessories",
+  Outerwear = "outerwear",
+  Tops = "tops",
+  Bottoms = "bottoms",
+  Shoes = "shoes",
+  Accessories = "accessories",
 }
 
 export const SUBCATEGORIES: Record<Category, string[]> = {


### PR DESCRIPTION
Avatar skeleton code following existing format (new tab + basic page)

AI Usage: I'd like to add a new page for Avatar creation. Please add the basic skeleton and navbar item for now
|before|after|
|--|--|
|<img width="585" height="1196" alt="Screenshot 2026-06-03 at 12 09 51 AM" src="https://github.com/user-attachments/assets/e1404f96-5d7c-4669-94d3-8b929646504e" />|<img width="585" height="1266" alt="Screenshot 2026-06-03 at 12 30 47 AM" src="https://github.com/user-attachments/assets/f125b424-5140-401b-88f5-a6d519e11eab" />|

Avatar 3-partition:
Changed old 'category' to 'subcategory' (jeans/skirt/trousers), and added new column 'category' (tops/bottoms/shoes/outerwear) enum. Also updated all references to ClostItem with new schema
|before|after|
|--|--|
|<img width="585" height="1266" alt="Screenshot 2026-06-03 at 12 30 47 AM" src="https://github.com/user-attachments/assets/f125b424-5140-401b-88f5-a6d519e11eab" />|<img width="585" height="1266" alt="Screenshot 2026-06-03 at 12 48 03 AM" src="https://github.com/user-attachments/assets/e26da1ed-1204-4812-bf95-4aac9034b560" />|