### PR TITLE
fix display of height when editing

### DIFF
--- a/client/app/(app)/(tabs)/profile.tsx
+++ b/client/app/(app)/(tabs)/profile.tsx
@@ -164,7 +164,9 @@ export default function ProfileScreen() {
                       ]}
                     />
                   </View>
-                  <Text style={[Typography.titleLg, styles.heightSep]}>&apos;</Text>
+                  <Text style={[Typography.titleLg, styles.heightSep]}>
+                    &apos;
+                  </Text>
                   <View style={[styles.inputWrap, styles.inchesWrap]}>
                     <TextInput
                       {...fieldProps}
@@ -186,7 +188,9 @@ export default function ProfileScreen() {
                       ]}
                     />
                   </View>
-                  <Text style={[Typography.titleLg, styles.heightSep]}>&quot;</Text>
+                  <Text style={[Typography.titleLg, styles.heightSep]}>
+                    &quot;
+                  </Text>
                 </View>
               </View>
             </View>
@@ -195,10 +199,7 @@ export default function ProfileScreen() {
           <View style={styles.card}>
             <Text style={styles.cardLabel}>GENDER</Text>
             <View
-              style={[
-                styles.cardField,
-                edit.editing && styles.genderField,
-              ]}
+              style={[styles.cardField, edit.editing && styles.genderField]}
             >
               {edit.editing ? (
                 <GenderPicker

--- a/client/app/(app)/(tabs)/profile.tsx
+++ b/client/app/(app)/(tabs)/profile.tsx
@@ -6,17 +6,73 @@ import {
   ScrollView,
   Text,
   TextInput,
+  type TextInputProps,
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { GenderPicker } from "@/components/profile/gender-picker";
 import { styles } from "@/components/profile/profile-styles";
-import { capitalize, getInitials } from "@/components/profile/profile-utils";
+import {
+  capitalize,
+  getInitials,
+  inchesToFeetAndInches,
+} from "@/components/profile/profile-utils";
 import { Palette, Typography } from "@/constants/design";
 import { useProfileEdit } from "@/hooks/use-profile-edit";
 import { signOut } from "@/lib/auth";
 import { getProfile, type UserProfile } from "@/lib/profile";
+
+type HeightEditorProps = {
+  feet: string;
+  inches: string;
+  setFeet: (value: string) => void;
+  setInches: (value: string) => void;
+  fieldProps: TextInputProps;
+};
+
+function HeightEditor({
+  feet,
+  inches,
+  setFeet,
+  setInches,
+  fieldProps,
+}: HeightEditorProps) {
+  return (
+    <View style={styles.heightRow}>
+      <View style={[styles.inputWrap, styles.feetWrap]}>
+        <TextInput
+          {...fieldProps}
+          style={[Typography.titleLg, styles.fieldInput]}
+          value={feet}
+          onChangeText={setFeet}
+          keyboardType="number-pad"
+          placeholder="ft"
+          placeholderTextColor={Palette.onSurfaceVariant}
+          maxLength={1}
+          returnKeyType="next"
+        />
+        <View style={styles.inputUnderline} />
+      </View>
+      <Text style={[Typography.titleLg, styles.heightSep]}>&apos;</Text>
+      <View style={[styles.inputWrap, styles.inchesWrap]}>
+        <TextInput
+          {...fieldProps}
+          style={[Typography.titleLg, styles.fieldInput]}
+          value={inches}
+          onChangeText={setInches}
+          keyboardType="number-pad"
+          placeholder="in"
+          placeholderTextColor={Palette.onSurfaceVariant}
+          maxLength={2}
+          returnKeyType="done"
+        />
+        <View style={styles.inputUnderline} />
+      </View>
+      <Text style={[Typography.titleLg, styles.heightSep]}>&quot;</Text>
+    </View>
+  );
+}
 
 export default function ProfileScreen() {
   const router = useRouter();
@@ -60,9 +116,7 @@ export default function ProfileScreen() {
     );
   }
 
-  const heightFeet = Math.floor((profile.height ?? 0) / 12);
-  const heightInches = (profile.height ?? 0) % 12;
-  const fieldProps = {
+  const fieldProps: TextInputProps = {
     editable: edit.editing,
     showSoftInputOnFocus: edit.editing,
     caretHidden: !edit.editing,
@@ -144,54 +198,19 @@ export default function ProfileScreen() {
             <View style={[styles.card, styles.cardHalf]}>
               <Text style={styles.cardLabel}>HEIGHT</Text>
               <View style={styles.cardField}>
-                <View style={styles.heightRow}>
-                  <View style={[styles.inputWrap, styles.feetWrap]}>
-                    <TextInput
-                      {...fieldProps}
-                      style={[Typography.titleLg, styles.fieldInput]}
-                      value={edit.editing ? edit.draftFeet : String(heightFeet)}
-                      onChangeText={edit.setDraftFeet}
-                      keyboardType="number-pad"
-                      placeholder="ft"
-                      placeholderTextColor={Palette.onSurfaceVariant}
-                      maxLength={1}
-                      returnKeyType="next"
-                    />
-                    <View
-                      style={[
-                        styles.inputUnderline,
-                        !edit.editing && styles.underlineHidden,
-                      ]}
-                    />
-                  </View>
-                  <Text style={[Typography.titleLg, styles.heightSep]}>
-                    &apos;
+                {edit.editing ? (
+                  <HeightEditor
+                    feet={edit.draftFeet}
+                    inches={edit.draftInches}
+                    setFeet={edit.setDraftFeet}
+                    setInches={edit.setDraftInches}
+                    fieldProps={fieldProps}
+                  />
+                ) : (
+                  <Text style={[Typography.titleLg, styles.cardValue]}>
+                    {inchesToFeetAndInches(profile.height)}
                   </Text>
-                  <View style={[styles.inputWrap, styles.inchesWrap]}>
-                    <TextInput
-                      {...fieldProps}
-                      style={[Typography.titleLg, styles.fieldInput]}
-                      value={
-                        edit.editing ? edit.draftInches : String(heightInches)
-                      }
-                      onChangeText={edit.setDraftInches}
-                      keyboardType="number-pad"
-                      placeholder="in"
-                      placeholderTextColor={Palette.onSurfaceVariant}
-                      maxLength={2}
-                      returnKeyType="done"
-                    />
-                    <View
-                      style={[
-                        styles.inputUnderline,
-                        !edit.editing && styles.underlineHidden,
-                      ]}
-                    />
-                  </View>
-                  <Text style={[Typography.titleLg, styles.heightSep]}>
-                    &quot;
-                  </Text>
-                </View>
+                )}
               </View>
             </View>
           </View>


### PR DESCRIPTION
Before, height display maintained gaps between number and ' or " despite not editing.
Done:
- Now, displays as one string:
<img width="65" height="71" alt="Screenshot 2026-06-04 at 2 15 38 AM" src="https://github.com/user-attachments/assets/37161178-0997-444c-ad97-7ccec3a0837a" />

