### PR TITLE
[TESTING + COMMENTS] Calendar + Collection Page Testing & AI Comment Integration

### DIFF
--- a/client/__tests__/calendar-utils.test.ts
+++ b/client/__tests__/calendar-utils.test.ts
@@ -1,0 +1,116 @@
+// [GenAI Use] Prompt:
+// "Write unit tests for calendar-utils.ts — formatMonthYear, formatDayLabel, addMonths,
+// getDaysInMonth, getCalendarCells, isCurrentMonth, getDefaultSelectedDay."
+// [GenAI Use] LLM Response Start
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  addMonths,
+  formatDayLabel,
+  formatMonthYear,
+  getCalendarCells,
+  getDaysInMonth,
+  getDefaultSelectedDay,
+  isCurrentMonth,
+} from "../components/calendar/calendar-utils";
+
+describe("calendar-utils", () => {
+  describe("formatMonthYear", () => {
+    it("formats month name and year", () => {
+      expect(formatMonthYear(new Date(2026, 5, 9))).toBe("June 2026");
+    });
+  });
+
+  describe("formatDayLabel", () => {
+    it("formats month name, day, and year", () => {
+      expect(formatDayLabel(2026, 5, 9)).toBe("June 9, 2026");
+    });
+  });
+
+  describe("addMonths", () => {
+    it("advances to the first of the target month", () => {
+      const result = addMonths(new Date(2026, 5, 15), 1);
+      expect(result.getFullYear()).toBe(2026);
+      expect(result.getMonth()).toBe(6);
+      expect(result.getDate()).toBe(1);
+    });
+
+    it("wraps into the next year", () => {
+      const result = addMonths(new Date(2026, 11, 20), 1);
+      expect(result.getFullYear()).toBe(2027);
+      expect(result.getMonth()).toBe(0);
+      expect(result.getDate()).toBe(1);
+    });
+  });
+
+  describe("getDaysInMonth", () => {
+    it("returns 31 for January", () => {
+      expect(getDaysInMonth(2026, 0)).toBe(31);
+    });
+
+    it("returns 29 for February in a leap year", () => {
+      expect(getDaysInMonth(2024, 1)).toBe(29);
+    });
+
+    it("returns 28 for February in a non-leap year", () => {
+      expect(getDaysInMonth(2026, 1)).toBe(28);
+    });
+  });
+
+  describe("getCalendarCells", () => {
+    it("pads leading blanks and includes every day in the month", () => {
+      const year = 2026;
+      const month = 5;
+      const firstWeekday = new Date(year, month, 1).getDay();
+      const daysInMonth = getDaysInMonth(year, month);
+
+      const cells = getCalendarCells(year, month);
+
+      expect(cells.filter((cell) => cell.day === null)).toHaveLength(firstWeekday);
+      expect(cells.filter((cell) => cell.day !== null)).toHaveLength(daysInMonth);
+      expect(cells.at(-1)?.day).toBe(daysInMonth);
+    });
+  });
+
+  describe("isCurrentMonth", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2026, 5, 9));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("returns true for the current month", () => {
+      expect(isCurrentMonth(new Date(2026, 5, 1))).toBe(true);
+    });
+
+    it("returns false for another month", () => {
+      expect(isCurrentMonth(new Date(2026, 4, 1))).toBe(false);
+    });
+  });
+
+  describe("getDefaultSelectedDay", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2026, 5, 9));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("returns today's day when viewing the current month", () => {
+      expect(getDefaultSelectedDay(new Date(2026, 5, 1))).toBe(9);
+    });
+
+    it("returns null when viewing a different month", () => {
+      expect(getDefaultSelectedDay(new Date(2026, 4, 1))).toBeNull();
+    });
+  });
+});
+// [GenAI Use] LLM Response End
+// [GenAI Use] Reflection:
+// Used fake timers for isCurrentMonth/getDefaultSelectedDay since they depend on today.
+// Verified getCalendarCells against getDaysInMonth rather than hard-coding weekday counts.

--- a/client/__tests__/calendar.test.ts
+++ b/client/__tests__/calendar.test.ts
@@ -1,0 +1,268 @@
+// [GenAI Use] Prompt:
+// "Write unit tests for loadCalendarMonth in lib/calendar.ts and loadDayWears in lib/wear-log.ts.
+// Mock Supabase using the chain() pattern from friends.test.ts."
+// [GenAI Use] LLM Response Start
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { loadCalendarMonth } from "../lib/calendar";
+import { loadDayWears } from "../lib/wear-log";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  from: vi.fn(),
+}));
+
+vi.mock("../lib/supabase", () => ({
+  supabase: {
+    auth: { getSession: mocks.getSession },
+    from: mocks.from,
+  },
+}));
+
+const UID = "user-123";
+
+function chain(result: unknown) {
+  const obj: any = {
+    then(resolve: (v: unknown) => void, reject?: (e: unknown) => void) {
+      return Promise.resolve(result).then(resolve, reject);
+    },
+  };
+  for (const m of ["select", "eq", "gte", "lte", "in", "insert", "single"]) {
+    obj[m] = () => obj;
+  }
+  return obj;
+}
+
+function mockMonthQueries(
+  logData: unknown,
+  statsData: unknown,
+  logError: unknown = null,
+  statsError: unknown = null,
+) {
+  mocks.from
+    .mockReturnValueOnce(chain({ data: logData, error: logError }))
+    .mockReturnValueOnce(chain({ data: statsData, error: statsError }));
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mocks.getSession.mockResolvedValue({
+    data: { session: { user: { id: UID } } },
+    error: null,
+  });
+});
+
+describe("loadCalendarMonth", () => {
+  it("throws when session lookup fails", async () => {
+    mocks.getSession.mockResolvedValue({
+      data: { session: null },
+      error: { message: "session error" },
+    });
+
+    await expect(loadCalendarMonth(2026, 5)).rejects.toThrow("session error");
+  });
+
+  it("throws when there is no active session", async () => {
+    mocks.getSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+
+    await expect(loadCalendarMonth(2026, 5)).rejects.toThrow(
+      "No active session.",
+    );
+  });
+
+  it("throws when the wear_log day query fails", async () => {
+    mocks.from.mockReturnValueOnce(
+      chain({ data: null, error: { message: "logs failed" } }),
+    );
+
+    await expect(loadCalendarMonth(2026, 5)).rejects.toThrow("logs failed");
+  });
+
+  it("throws when the stats query fails", async () => {
+    mockMonthQueries([], null, null, { message: "stats failed" });
+
+    await expect(loadCalendarMonth(2026, 5)).rejects.toThrow("stats failed");
+  });
+
+  it("returns empty outfitDays and stats for an empty month", async () => {
+    mockMonthQueries([], []);
+
+    const result = await loadCalendarMonth(2026, 5);
+
+    expect(result).toEqual({ outfitDays: [], stats: [] });
+  });
+
+  it("dedupes and sorts outfitDays", async () => {
+    mockMonthQueries(
+      [
+        { worn_on: "2026-06-15" },
+        { worn_on: "2026-06-03" },
+        { worn_on: "2026-06-15" },
+      ],
+      [],
+    );
+
+    const result = await loadCalendarMonth(2026, 5);
+
+    expect(result.outfitDays).toEqual([3, 15]);
+  });
+
+  it("returns top 3 worn items with zero-padded ranks", async () => {
+    mockMonthQueries([], [
+      {
+        outfits: {
+          outfit_items: [
+            {
+              items: {
+                id: "a",
+                item_name: "Jacket",
+                image_url: "https://img/a.jpg",
+              },
+            },
+            {
+              items: {
+                id: "b",
+                item_name: "Jeans",
+                image_url: null,
+              },
+            },
+          ],
+        },
+      },
+      {
+        outfits: {
+          outfit_items: [
+            {
+              items: {
+                id: "a",
+                item_name: "Jacket",
+                image_url: "https://img/a.jpg",
+              },
+            },
+          ],
+        },
+      },
+      {
+        outfits: {
+          outfit_items: [
+            {
+              items: {
+                id: "b",
+                item_name: "Jeans",
+                image_url: null,
+              },
+            },
+          ],
+        },
+      },
+      {
+        outfits: {
+          outfit_items: [
+            {
+              items: {
+                id: "c",
+                item_name: null,
+                image_url: "https://img/c.jpg",
+              },
+            },
+          ],
+        },
+      },
+    ]);
+
+    const result = await loadCalendarMonth(2026, 5);
+
+    expect(result.stats).toHaveLength(3);
+    expect(result.stats[0]).toMatchObject({
+      rank: "01",
+      name: "Jacket",
+      wears: 2,
+      imageUri: "https://img/a.jpg",
+    });
+    expect(result.stats[1]).toMatchObject({
+      rank: "02",
+      name: "Jeans",
+      wears: 2,
+    });
+    expect(result.stats[2]).toMatchObject({
+      rank: "03",
+      name: "Untitled item",
+      wears: 1,
+      imageUri: "https://img/c.jpg",
+    });
+  });
+});
+
+describe("loadDayWears", () => {
+  it("throws when there is no active session", async () => {
+    mocks.getSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+
+    await expect(loadDayWears(2026, 5, 9)).rejects.toThrow("No active session.");
+  });
+
+  it("returns an empty array when there are no logs", async () => {
+    mocks.from.mockReturnValue(chain({ data: [], error: null }));
+
+    expect(await loadDayWears(2026, 5, 9)).toEqual([]);
+  });
+
+  it("maps wear log entries and nested items", async () => {
+    mocks.from.mockReturnValue(
+      chain({
+        data: [
+          {
+            id: "log-1",
+            outfit_id: "outfit-1",
+            worn_on: "2026-06-09",
+            outfits: {
+              outfit_items: [
+                {
+                  items: {
+                    id: "item-1",
+                    item_name: "Shirt",
+                    image_url: "https://img/shirt.jpg",
+                  },
+                },
+                { items: null },
+              ],
+            },
+          },
+        ],
+        error: null,
+      }),
+    );
+
+    const result = await loadDayWears(2026, 5, 9);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      wearLogId: "log-1",
+      outfitId: "outfit-1",
+      wornOn: "2026-06-09",
+    });
+    expect(result[0].items).toHaveLength(1);
+    expect(result[0].items[0]).toMatchObject({
+      id: "item-1",
+      item_name: "Shirt",
+      image_url: "https://img/shirt.jpg",
+    });
+  });
+
+  it("throws when the wear_log query fails", async () => {
+    mocks.from.mockReturnValue(
+      chain({ data: null, error: { message: "day query failed" } }),
+    );
+
+    await expect(loadDayWears(2026, 5, 9)).rejects.toThrow("day query failed");
+  });
+});
+// [GenAI Use] LLM Response End
+// [GenAI Use] Reflection:
+// loadCalendarMonth hits wear_log twice, so mocks use mockReturnValueOnce in order.
+// Confirmed stats ranking and "Untitled item" fallback against the source logic.

--- a/client/__tests__/collections.test.ts
+++ b/client/__tests__/collections.test.ts
@@ -1,0 +1,446 @@
+// [GenAI Use] Prompt:
+// "Write unit tests for lib/collections.ts. Mock Supabase like friends.test.ts.
+// Cover slotted vs bucket outfits, mapping, createCollection, addItemsToCollection, deleteCollection."
+// [GenAI Use] LLM Response Start
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  addItemsToCollection,
+  addOutfitToCollections,
+  createCollection,
+  deleteCollection,
+  fetchCollectionDetail,
+  fetchCollections,
+  removeItemFromCollection,
+  removeOutfitFromCollection,
+} from "../lib/collections";
+import type { ClosetItem } from "../lib/types/closet";
+
+const mocks = vi.hoisted(() => ({
+  from: vi.fn(),
+}));
+
+vi.mock("../lib/supabase", () => ({
+  supabase: { from: mocks.from },
+}));
+
+const UID = "user-123";
+const COLLECTION_ID = "col-1";
+
+function chain(result: unknown) {
+  const obj: any = {
+    then(resolve: (v: unknown) => void, reject?: (e: unknown) => void) {
+      return Promise.resolve(result).then(resolve, reject);
+    },
+  };
+  for (const m of [
+    "select",
+    "eq",
+    "order",
+    "single",
+    "insert",
+    "delete",
+    "in",
+  ]) {
+    obj[m] = () => obj;
+  }
+  return obj;
+}
+
+function makeItem(id: string, overrides: Partial<ClosetItem> = {}): ClosetItem {
+  return {
+    id,
+    user_id: UID,
+    category: "Top",
+    subcategory: "Shirt",
+    item_name: `Item ${id}`,
+    image_url: `https://img/${id}.jpg`,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeSlottedOutfit(id = "outfit-slotted") {
+  return {
+    id,
+    name: "Saved Look",
+    outfit_items: [
+      {
+        slot: "top",
+        item_id: "item-1",
+        items: makeItem("item-1"),
+      },
+    ],
+  };
+}
+
+function makeBucketOutfit(id = "outfit-bucket") {
+  return {
+    id,
+    name: "Favorites",
+    outfit_items: [
+      {
+        slot: null,
+        item_id: "item-2",
+        items: makeItem("item-2"),
+      },
+    ],
+  };
+}
+
+function makeCollectionRow(
+  outfits: unknown[],
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    id: COLLECTION_ID,
+    user_id: UID,
+    name: "Favorites",
+    is_favorite: false,
+    collection_outfits: outfits.map((outfit) => ({ outfits: outfit })),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("fetchCollections", () => {
+  it("throws on supabase error", async () => {
+    mocks.from.mockReturnValue(
+      chain({ data: null, error: { message: "fetch failed" } }),
+    );
+
+    await expect(fetchCollections(UID)).rejects.toThrow("fetch failed");
+  });
+
+  it("maps slotted outfits to outfit_count and all items to item_count", async () => {
+    mocks.from.mockReturnValue(
+      chain({
+        data: [makeCollectionRow([makeSlottedOutfit(), makeBucketOutfit()])],
+        error: null,
+      }),
+    );
+
+    const result = await fetchCollections(UID);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: COLLECTION_ID,
+      outfit_count: 1,
+      item_count: 2,
+      thumbnail_urls: ["https://img/item-1.jpg", "https://img/item-2.jpg"],
+    });
+  });
+
+  it("caps thumbnail_urls at four images", async () => {
+    const bucket = {
+      id: "bucket-many",
+      name: "Favorites",
+      outfit_items: Array.from({ length: 5 }, (_, i) => ({
+        slot: null,
+        item_id: `item-${i}`,
+        items: makeItem(`item-${i}`),
+      })),
+    };
+
+    mocks.from.mockReturnValue(
+      chain({ data: [makeCollectionRow([bucket])], error: null }),
+    );
+
+    const result = await fetchCollections(UID);
+
+    expect(result[0].item_count).toBe(5);
+    expect(result[0].thumbnail_urls).toHaveLength(4);
+  });
+});
+
+describe("fetchCollectionDetail", () => {
+  it("throws on supabase error", async () => {
+    mocks.from.mockReturnValue(
+      chain({ data: null, error: { message: "detail failed" } }),
+    );
+
+    await expect(fetchCollectionDetail(COLLECTION_ID)).rejects.toThrow(
+      "detail failed",
+    );
+  });
+
+  it("returns slotted outfits only and dedupes items across outfits", async () => {
+    const sharedItem = makeItem("shared");
+    const row = makeCollectionRow([
+      {
+        id: "outfit-a",
+        name: "Look A",
+        outfit_items: [
+          { slot: "top", item_id: "shared", items: sharedItem },
+        ],
+      },
+      {
+        id: "outfit-b",
+        name: "Look B",
+        outfit_items: [
+          { slot: "bottom", item_id: "shared", items: sharedItem },
+          { slot: "shoes", item_id: "item-shoes", items: makeItem("item-shoes") },
+        ],
+      },
+      makeBucketOutfit(),
+    ]);
+
+    mocks.from.mockReturnValue(chain({ data: row, error: null }));
+
+    const result = await fetchCollectionDetail(COLLECTION_ID);
+
+    expect(result.outfit_count).toBe(2);
+    expect(result.item_count).toBe(3);
+    expect(result.outfits).toHaveLength(2);
+    expect(result.items).toHaveLength(3);
+    expect(result.outfits[0].items[0]).toMatchObject({
+      slot: "top",
+      item: expect.objectContaining({ id: "shared" }),
+    });
+  });
+
+  it("excludes bucket outfits from the outfits list", async () => {
+    mocks.from.mockReturnValue(
+      chain({
+        data: makeCollectionRow([makeBucketOutfit()]),
+        error: null,
+      }),
+    );
+
+    const result = await fetchCollectionDetail(COLLECTION_ID);
+
+    expect(result.outfit_count).toBe(0);
+    expect(result.item_count).toBe(1);
+    expect(result.outfits).toEqual([]);
+    expect(result.items).toHaveLength(1);
+  });
+});
+
+describe("createCollection", () => {
+  it("throws when name is blank", async () => {
+    await expect(createCollection(UID, "   ")).rejects.toThrow(
+      "Collection name is required.",
+    );
+  });
+
+  it("creates a collection without items", async () => {
+    mocks.from.mockReturnValue(
+      chain({
+        data: [
+          {
+            id: COLLECTION_ID,
+            user_id: UID,
+            name: "New",
+            is_favorite: false,
+          },
+        ],
+        error: null,
+      }),
+    );
+
+    const result = await createCollection(UID, "New");
+
+    expect(result).toMatchObject({
+      id: COLLECTION_ID,
+      name: "New",
+      outfit_count: 0,
+      item_count: 0,
+      thumbnail_urls: [],
+    });
+  });
+
+  it("creates a bucket outfit when initial items are provided", async () => {
+    mocks.from
+      .mockReturnValueOnce(
+        chain({
+          data: [
+            {
+              id: COLLECTION_ID,
+              user_id: UID,
+              name: "Packed",
+              is_favorite: false,
+            },
+          ],
+          error: null,
+        }),
+      )
+      .mockReturnValueOnce(chain({ data: [{ id: "outfit-new" }], error: null }))
+      .mockReturnValueOnce(chain({ error: null }))
+      .mockReturnValueOnce(chain({ error: null }))
+      .mockReturnValueOnce(
+        chain({
+          data: [{ image_url: "https://img/a.jpg" }, { image_url: null }],
+          error: null,
+        }),
+      );
+
+    const result = await createCollection(UID, "Packed", ["item-a", "item-b"]);
+
+    expect(result).toMatchObject({
+      item_count: 2,
+      outfit_count: 0,
+      thumbnail_urls: ["https://img/a.jpg"],
+    });
+  });
+});
+
+describe("addOutfitToCollections", () => {
+  it("no-ops when collectionIds is empty", async () => {
+    await addOutfitToCollections("outfit-1", []);
+    expect(mocks.from).not.toHaveBeenCalled();
+  });
+
+  it("inserts collection_outfit links", async () => {
+    mocks.from.mockReturnValue(chain({ error: null }));
+
+    await expect(
+      addOutfitToCollections("outfit-1", ["col-a", "col-b"]),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws on insert error", async () => {
+    mocks.from.mockReturnValue(
+      chain({ error: { message: "link failed" } }),
+    );
+
+    await expect(
+      addOutfitToCollections("outfit-1", ["col-a"]),
+    ).rejects.toThrow("link failed");
+  });
+});
+
+describe("removeOutfitFromCollection", () => {
+  it("resolves on success", async () => {
+    mocks.from.mockReturnValue(chain({ error: null }));
+    await expect(
+      removeOutfitFromCollection(COLLECTION_ID, "outfit-1"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws on delete error", async () => {
+    mocks.from.mockReturnValue(
+      chain({ error: { message: "remove outfit failed" } }),
+    );
+
+    await expect(
+      removeOutfitFromCollection(COLLECTION_ID, "outfit-1"),
+    ).rejects.toThrow("remove outfit failed");
+  });
+});
+
+describe("removeItemFromCollection", () => {
+  it("no-ops when the collection has no linked outfits", async () => {
+    mocks.from.mockReturnValueOnce(chain({ data: [], error: null }));
+
+    await removeItemFromCollection(COLLECTION_ID, "item-1");
+
+    expect(mocks.from).toHaveBeenCalledTimes(1);
+  });
+
+  it("deletes outfit_items for linked outfits", async () => {
+    mocks.from
+      .mockReturnValueOnce(
+        chain({ data: [{ outfit_id: "outfit-1" }], error: null }),
+      )
+      .mockReturnValueOnce(chain({ error: null }));
+
+    await expect(
+      removeItemFromCollection(COLLECTION_ID, "item-1"),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("addItemsToCollection", () => {
+  it("no-ops when itemIds is empty", async () => {
+    await addItemsToCollection(COLLECTION_ID, UID, "Favorites", []);
+    expect(mocks.from).not.toHaveBeenCalled();
+  });
+
+  it("reuses an existing bucket outfit and skips duplicate item ids", async () => {
+    mocks.from
+      .mockReturnValueOnce(
+        chain({ data: [{ outfit_id: "bucket-1" }], error: null }),
+      )
+      .mockReturnValueOnce(
+        chain({
+          data: [{ outfit_id: "saved-1", slot: "top" }],
+          error: null,
+        }),
+      )
+      .mockReturnValueOnce(
+        chain({ data: [{ item_id: "item-1" }], error: null }),
+      )
+      .mockReturnValueOnce(chain({ error: null }));
+
+    await addItemsToCollection(COLLECTION_ID, UID, "Favorites", [
+      "item-1",
+      "item-2",
+    ]);
+
+    expect(mocks.from).toHaveBeenCalledTimes(4);
+  });
+
+  it("creates a bucket outfit when none exists", async () => {
+    mocks.from
+      .mockReturnValueOnce(chain({ data: [], error: null }))
+      .mockReturnValueOnce(
+        chain({ data: [{ id: "bucket-new" }], error: null }),
+      )
+      .mockReturnValueOnce(chain({ error: null }))
+      .mockReturnValueOnce(chain({ data: [], error: null }))
+      .mockReturnValueOnce(chain({ error: null }));
+
+    await expect(
+      addItemsToCollection(COLLECTION_ID, UID, "Favorites", ["item-1"]),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.from).toHaveBeenCalledTimes(5);
+  });
+});
+
+describe("deleteCollection", () => {
+  it("deletes bucket outfits but keeps slotted outfit links cleaned up safely", async () => {
+    mocks.from
+      .mockReturnValueOnce(
+        chain({
+          data: [{ outfit_id: "saved-1" }, { outfit_id: "bucket-1" }],
+          error: null,
+        }),
+      )
+      .mockReturnValueOnce(
+        chain({
+          data: [{ outfit_id: "saved-1", slot: "top" }],
+          error: null,
+        }),
+      )
+      .mockReturnValueOnce(chain({ error: null }))
+      .mockReturnValueOnce(chain({ error: null }))
+      .mockReturnValueOnce(chain({ error: null }))
+      .mockReturnValueOnce(chain({ error: null }));
+
+    await expect(deleteCollection(COLLECTION_ID)).resolves.toBeUndefined();
+
+    expect(mocks.from).toHaveBeenCalledTimes(6);
+  });
+
+  it("throws when slot lookup fails", async () => {
+    mocks.from
+      .mockReturnValueOnce(
+        chain({ data: [{ outfit_id: "outfit-1" }], error: null }),
+      )
+      .mockReturnValueOnce(
+        chain({ data: null, error: { message: "slot lookup failed" } }),
+      );
+
+    await expect(deleteCollection(COLLECTION_ID)).rejects.toThrow(
+      "slot lookup failed",
+    );
+  });
+});
+// [GenAI Use] LLM Response End
+// [GenAI Use] Reflection:
+// Bucket outfits have no slots, so they count toward item_count but not outfit_count.
+// Multi-step flows use mockReturnValueOnce in call order; verified against collections.ts.

--- a/client/__tests__/wear-log.test.ts
+++ b/client/__tests__/wear-log.test.ts
@@ -1,0 +1,28 @@
+// [GenAI Use] Prompt:
+// "Write unit tests for formatWornOn in lib/wear-log.ts. Month arg is 0-indexed."
+// [GenAI Use] LLM Response Start
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/supabase", () => ({
+  supabase: { auth: { getSession: vi.fn() }, from: vi.fn() },
+}));
+
+import { formatWornOn } from "../lib/wear-log";
+
+describe("formatWornOn", () => {
+  it("formats a date with zero-padded month and day", () => {
+    expect(formatWornOn(2026, 5, 9)).toBe("2026-06-09");
+  });
+
+  it("zero-pads single-digit month and day", () => {
+    expect(formatWornOn(2026, 0, 5)).toBe("2026-01-05");
+  });
+
+  it("handles end-of-month dates", () => {
+    expect(formatWornOn(2026, 1, 28)).toBe("2026-02-28");
+  });
+});
+// [GenAI Use] LLM Response End
+// [GenAI Use] Reflection:
+// Confirmed month is 0-indexed in the source (month + 1 in the formatter).
+// Mocked supabase so importing wear-log.ts does not require env vars.

--- a/client/app/(app)/(tabs)/collections.tsx
+++ b/client/app/(app)/(tabs)/collections.tsx
@@ -229,6 +229,8 @@ export default function CollectionsScreen() {
   );
 }
 
+// [GenAI Use] Prompt: style the collections list — 2-column grid, thumbnail mosaic, create button.
+// [GenAI Use] Reflection: adjusted card width and image border to fit the tab layout.
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,

--- a/client/components/calendar/calendar-styles.ts
+++ b/client/components/calendar/calendar-styles.ts
@@ -5,6 +5,8 @@ import { Palette, Radius, Spacing, Typography } from "@/constants/design";
 const DAY_CELL_WIDTH = "14.28%";
 const DAY_MARKER_SIZE = 44;
 
+// [GenAI Use] Prompt: style the calendar page — month header, day grid, OOTD/stats toggle.
+// [GenAI Use] Reflection: matched spacing and toggle styling to the collections detail screen.
 export const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
@@ -103,6 +105,8 @@ export const styles = StyleSheet.create({
     borderRadius: 1.5,
     backgroundColor: Palette.primary,
   },
+  // [GenAI Use] Prompt: style the OOTD carousel and monthly stats section below the calendar grid.
+  // [GenAI Use] Reflection: aligned section titles and empty states with the collections tab.
   statsSection: {
     marginTop: 0,
   },

--- a/client/components/calendar/stat-rank-card.tsx
+++ b/client/components/calendar/stat-rank-card.tsx
@@ -74,6 +74,8 @@ export function StatRankCard({ item, variant, style }: Props) {
   );
 }
 
+// [GenAI Use] Prompt: style the monthly stats rank cards — hero and compact variants.
+// [GenAI Use] Reflection: tuned overlay text and pill badges for readability on item photos.
 const styles = StyleSheet.create({
   card: {
     borderRadius: Radius.lg,

--- a/client/components/collections/collection-detail-screen.tsx
+++ b/client/components/collections/collection-detail-screen.tsx
@@ -491,6 +491,8 @@ export function CollectionDetailScreen({ collectionId }: Props) {
   );
 }
 
+// [GenAI Use] Prompt: style collection detail — header menu, outfits/items toggle, edit bottom bar.
+// [GenAI Use] Reflection: kept the add-items button aligned with the collections tab CTA.
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,

--- a/client/components/collections/collection-outfit-card.tsx
+++ b/client/components/collections/collection-outfit-card.tsx
@@ -35,6 +35,8 @@ export function CollectionOutfitCard({ outfit }: Props) {
   );
 }
 
+// [GenAI Use] Prompt: style the outfit card thumbnail grid for the collection detail view.
+// [GenAI Use] Reflection: reused the 2x2 mosaic layout from the collections list page.
 const styles = StyleSheet.create({
   card: {
     width: '100%',

--- a/client/components/collections/create-collection-modal.tsx
+++ b/client/components/collections/create-collection-modal.tsx
@@ -174,6 +174,8 @@ export function CreateCollectionModal({
   );
 }
 
+// [GenAI Use] Prompt: style the create/add-to-collection modal — sheet, item picker grid, actions.
+// [GenAI Use] Reflection: matched cancel/confirm buttons to the onboarding modal pattern.
 const styles = StyleSheet.create({
   overlay: {
     flex: 1,


### PR DESCRIPTION
Summary
- 47 unit tests for collections and calendar: date helpers, formatWornOn, calendar month/day loading, and collections fetch/create/delete
- Collections tests cover bucket vs slotted outfits, thumbnail limits, item deduping, and add/delete flows
- Data layer tests use predefined Supabase responses so tests run without a live database or sign in
- Each test file includes [GenAI Use] prompt and reflection comments
- Adds GenAI styling comments on 6 collections and calendar UI files