### PR TITLE
Add unit tests for Gemini and Remove.bg services using Vitest

### DIFF
--- a/server/__tests__/services/gemini.test.ts
+++ b/server/__tests__/services/gemini.test.ts
@@ -1,0 +1,206 @@
+// [GenAI Use] Prompt: "I need to write gemini.test.ts for my FITTED project. The goal is to unit test the service without making real API calls, so use Vitest mocks/stubs/spies to isolate it from the external Gemini API. Cover missing API key handling, request payload correctness, successful inline image extraction, and failure cases like non-OK responses, non-JSON responses, and missing image data."
+// [GenAI Use] Reflection: Most of the generated tests were mostly well written and passing. I made a few improvements by adding a missing network failure test case, improving readability in some assertions, and ensuring the test style remained consistent with the rest of the project's codebase and testing conventions.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { standardizeImage } from "../../src/services/gemini";
+
+const originalFetch = globalThis.fetch;
+const originalApiKey = process.env.GEMINI_API_KEY;
+
+function makeJsonResponse(body: unknown, ok: boolean = true) {
+  return {
+    ok,
+    status: ok ? 200 : 500,
+    statusText: ok ? "OK" : "Internal Server Error",
+    text: vi.fn().mockResolvedValue(JSON.stringify(body)),
+  } as any;
+}
+
+describe("standardizeImage", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.GEMINI_API_KEY = "test-gemini-key";
+  });
+
+  afterEach(() => {
+    if (originalFetch) {
+      globalThis.fetch = originalFetch;
+    }
+
+    if (originalApiKey === undefined) {
+      delete process.env.GEMINI_API_KEY;
+    } else {
+      process.env.GEMINI_API_KEY = originalApiKey;
+    }
+  });
+
+  it("throws when the Gemini API key is missing", async () => {
+    delete process.env.GEMINI_API_KEY;
+
+    await expect(standardizeImage("abcd")).rejects.toThrow(
+      "Missing Gemini API key: set GEMINI_API_KEY in the server environment.",
+    );
+  });
+
+  it("sends the expected request for a data URL input", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      makeJsonResponse({
+        candidates: [
+          {
+            content: {
+              parts: [{ inlineData: { data: "standardized-image-base64" } }],
+            },
+          },
+        ],
+      }),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await standardizeImage("data:image/png;base64,ABC123");
+
+    expect(result).toBe("standardized-image-base64");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-image-preview:generateContent",
+    );
+    expect(options.method).toBe("POST");
+    expect(options.headers).toEqual({
+      "content-type": "application/json",
+      "x-goog-api-key": "test-gemini-key",
+    });
+
+    const body = JSON.parse(options.body);
+    expect(body.contents).toHaveLength(1);
+    const content = body.contents[0];
+
+    expect(content.role).toBe("user");
+    expect(content.parts).toHaveLength(2);
+    expect(content.parts[0].text).toContain(
+      "Transform the provided image into a clean e-commerce style apparel product photo.",
+    );
+    expect(content.parts[0].text).toContain(
+      "Do NOT stylize, redesign, or invent new details.",
+    );
+    expect(content.parts[1]).toEqual({
+      inlineData: {
+        mimeType: "image/png",
+        data: "ABC123",
+      },
+    });
+    expect(body.generationConfig).toEqual({
+      responseModalities: ["TEXT", "IMAGE"],
+      imageConfig: {
+        aspectRatio: "1:1",
+        imageSize: "1K",
+      },
+    });
+  });
+
+  it("defaults raw base64 input to image/jpeg", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      makeJsonResponse({
+        candidates: [
+          {
+            content: {
+              parts: [{ inlineData: { data: "jpeg-output" } }],
+            },
+          },
+        ],
+      }),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await standardizeImage("RAWBASE64DATA");
+
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options.body);
+
+    expect(body.contents[0].parts[1]).toEqual({
+      inlineData: {
+        mimeType: "image/jpeg",
+        data: "RAWBASE64DATA",
+      },
+    });
+  });
+
+  it("returns the first non-thought inline image", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      makeJsonResponse({
+        candidates: [
+          {
+            content: {
+              parts: [
+                { thought: true, inlineData: { data: "ignore-this" } },
+                { inlineData: { data: "first-real-image" } },
+                { inlineData: { data: "second-real-image" } },
+              ],
+            },
+          },
+        ],
+      }),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await expect(standardizeImage("abcd")).resolves.toBe("first-real-image");
+  });
+
+  it("throws a Gemini API error when the HTTP response is not ok", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      text: vi.fn().mockResolvedValue("backend exploded"),
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await expect(standardizeImage("abcd")).rejects.toThrow(
+      "Gemini API error (500 Internal Server Error): backend exploded",
+    );
+  });
+
+  it("propagates fetch failures", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockRejectedValue(new Error("network error")) as typeof fetch;
+
+    await expect(standardizeImage("abcd")).rejects.toThrow("network error");
+  });
+
+  it("throws when Gemini returns non-JSON text", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: vi.fn().mockResolvedValue("<html>not json</html>"),
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await expect(standardizeImage("abcd")).rejects.toThrow(
+      "Gemini API returned non-JSON response: <html>not json</html>",
+    );
+  });
+
+  it("throws when no image is returned in the response parts", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      makeJsonResponse({
+        candidates: [
+          {
+            finishReason: "STOP",
+            content: {
+              parts: [{ text: "I could not generate an image." }],
+            },
+          },
+        ],
+        promptFeedback: { blockReason: "NONE" },
+      }),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await expect(standardizeImage("abcd")).rejects.toThrow(
+      "Generation failed: No image returned in the response parts.",
+    );
+  });
+});

--- a/server/__tests__/services/removebg.test.ts
+++ b/server/__tests__/services/removebg.test.ts
@@ -1,0 +1,122 @@
+// [GenAI Use] Prompt: "I need to write removebg.test.ts for my FITTED project. The goal is to unit test the service without making real API calls, so use Vitest mocks/stubs/spies to isolate it from the remove.bg API. Cover missing API key handling, request payload correctness, successful PNG response conversion, and error handling for specific HTTP statuses and generic server failures."
+// [GenAI Use] Reflection: Most of the generated tests were mostly well written and passing. I made a few improvements by adding a missing network failure test case, improving readability in some assertions, and ensuring the test style remained consistent with the rest of the project's codebase and testing conventions.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { removeBackground } from "../../src/services/removebg";
+
+const originalFetch = globalThis.fetch;
+const originalApiKey = process.env.REMOVE_BG_API_KEY;
+
+function makeImageResponse(bytes: number[]) {
+  const imageBuffer = Uint8Array.from(bytes);
+
+  return {
+    ok: true,
+    status: 200,
+    text: vi.fn(),
+    arrayBuffer: vi.fn().mockResolvedValue(imageBuffer.buffer),
+  } as any;
+}
+
+describe("removeBackground", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.REMOVE_BG_API_KEY = "test-removebg-key";
+  });
+
+  afterEach(() => {
+    if (originalFetch) {
+      globalThis.fetch = originalFetch;
+    }
+
+    if (originalApiKey === undefined) {
+      delete process.env.REMOVE_BG_API_KEY;
+    } else {
+      process.env.REMOVE_BG_API_KEY = originalApiKey;
+    }
+  });
+
+  it("throws when the remove.bg API key is missing", async () => {
+    delete process.env.REMOVE_BG_API_KEY;
+
+    await expect(removeBackground("abcd")).rejects.toThrow(
+      "Missing remove.bg API key: set REMOVE_BG_API_KEY in the environment.",
+    );
+  });
+
+  it("strips the data URL prefix and sends the expected request payload", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeImageResponse([1, 2, 3]));
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await removeBackground("data:image/jpeg;base64,ABC123");
+
+    expect(result).toBe("data:image/png;base64,AQID");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.remove.bg/v1.0/removebg");
+    expect(options.method).toBe("POST");
+    expect(options.headers).toEqual({
+      "Content-Type": "application/json",
+      "X-Api-Key": "test-removebg-key",
+      Accept: "image/png",
+    });
+
+    const body = JSON.parse(options.body);
+    expect(body).toEqual({
+      image_file_b64: "ABC123",
+      size: "auto",
+      format: "png",
+      type: "product",
+      crop: true,
+    });
+  });
+
+  it("removes whitespace from raw base64 input before sending it", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeImageResponse([9, 8, 7]));
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await removeBackground("AB C\n12\t3");
+
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options.body);
+
+    expect(body.image_file_b64).toBe("ABC123");
+  });
+
+  it.each([
+    [402, "remove.bg: Insufficient credits."],
+    [403, "remove.bg: Authentication failed."],
+    [429, "remove.bg: Rate limit exceeded."],
+  ])("maps status %i correctly", async (status, message) => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status,
+      text: vi.fn().mockResolvedValue("error"),
+    }) as typeof fetch;
+
+    await expect(removeBackground("abcd")).rejects.toThrow(message);
+  });
+
+  it("propagates fetch failures", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockRejectedValue(new Error("network error")) as typeof fetch;
+
+    await expect(removeBackground("abcd")).rejects.toThrow("network error");
+  });
+
+  it("throws a generic API error for other non-OK responses", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: vi.fn().mockResolvedValue("server error"),
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await expect(removeBackground("abcd")).rejects.toThrow(
+      "remove.bg API error (500): server error",
+    );
+  });
+});


### PR DESCRIPTION
Adds unit test coverage for the new gemini and removebg server services using Vitest with mocked fetch calls.

The tests cover 
- missing API key handling
- request payload correctness
- successful image responses,
- key failure cases such as non-OK API responses, invalid response formats, and network errors. 

All tests pass