### PR TITLE
test-cases for upload route

### DIFF
--- a/server/__tests__/services/uploads.test.ts
+++ b/server/__tests__/services/uploads.test.ts
@@ -1,0 +1,357 @@
+// [GenAI Use] Prompt: "Write Vitest tests for an Express router with three routes: POST /prepare-image,
+// POST /confirm-image, and POST /upload-image. The router uses Supabase for auth and DB inserts,
+// multer for file uploads, and calls standardizeImage and uploadToStorage services.
+// Mock all external dependencies using vi.mock. Cover auth failures, input validation,
+// happy paths, service failures, and the separation of concerns between the two upload routes."
+// [GenAI Use] Reflection: Trimmed redundant cases (duplicate file type checks, repeated auth
+// failure patterns across routes, empty-body variant already covered by individual missing-field
+// tests). Kept separation-of-concerns assertions (TC-06, TC-13) as they test non-obvious
+// architectural invariants specific to the prepare/confirm two-step flow. Fixed Supabase mock
+// wiring using vi.hoisted() so the mock instance exists before the route module loads and calls
+// createClient at import time.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+import express from "express";
+
+// ─── Hoist mock instance so it exists before any imports run ─────────────────
+// createClient is called at the TOP LEVEL of the route module when it loads,
+// so the mock return value must be set up before that import happens.
+// vi.hoisted() guarantees this block runs before all vi.mock() factories.
+
+const { mockGetUser, mockInsert, mockSupabaseInstance } = vi.hoisted(() => {
+  const mockGetUser = vi.fn();
+  const mockInsert = vi.fn();
+  const mockSupabaseInstance = {
+    auth: { getUser: mockGetUser },
+    from: vi.fn(() => ({ insert: mockInsert })),
+    storage: { from: vi.fn() },
+  };
+  return { mockGetUser, mockInsert, mockSupabaseInstance };
+});
+
+// ─── Mock external dependencies ──────────────────────────────────────────────
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn(() => mockSupabaseInstance),
+}));
+
+vi.mock("../../src/services/gemini", () => ({
+  standardizeImage: vi.fn(),
+}));
+
+vi.mock("../../src/services/removebg", () => ({
+  removeBackground: vi.fn(),
+}));
+
+vi.mock("../../src/services/storage", () => ({
+  uploadToStorage: vi.fn(),
+}));
+
+// ─── Import AFTER mocks ───────────────────────────────────────────────────────
+
+import { standardizeImage } from "../../src/services/gemini";
+import { uploadToStorage } from "../../src/services/storage";
+import imageRouter from "../../src/routes/upload";
+
+// ─── Typed mock references ────────────────────────────────────────────────────
+
+const mockStandardizeImage = vi.mocked(standardizeImage);
+const mockUploadToStorage = vi.mocked(uploadToStorage);
+
+// ─── App factory + auth helpers ──────────────────────────────────────────────
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api", imageRouter);
+  return app;
+}
+
+function mockAuthSuccess(userId = "user-123") {
+  mockGetUser.mockResolvedValue({ data: { user: { id: userId } } });
+}
+
+function mockAuthFailure() {
+  mockGetUser.mockResolvedValue({ data: { user: null } });
+}
+
+// ─── Shared setup ─────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Re-wire from() after clearAllMocks resets it
+  mockSupabaseInstance.from.mockReturnValue({ insert: mockInsert });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/prepare-image
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("POST /api/prepare-image", () => {
+  const app = buildApp();
+
+  // TC-01: No token
+  it("TC-01 | returns 401 when no Authorization header is provided", async () => {
+    const res = await request(app)
+      .post("/api/prepare-image")
+      .attach("image", Buffer.from("fake-image"), {
+        filename: "shirt.jpg",
+        contentType: "image/jpeg",
+      });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("no token");
+  });
+
+  // TC-02: Invalid token → Supabase returns null user
+  it("TC-02 | returns 401 when token is invalid or expired", async () => {
+    mockAuthFailure();
+
+    const res = await request(app)
+      .post("/api/prepare-image")
+      .set("Authorization", "Bearer bad-token")
+      .attach("image", Buffer.from("fake-image"), {
+        filename: "shirt.jpg",
+        contentType: "image/jpeg",
+      });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("unauthorized");
+  });
+
+  // TC-03: Wrong file type — multer fileFilter rejects before route logic
+  it("TC-03 | returns 400 when file type is not JPEG, PNG, or WebP", async () => {
+    mockAuthSuccess();
+
+    const res = await request(app)
+      .post("/api/prepare-image")
+      .set("Authorization", "Bearer valid-token")
+      .attach("image", Buffer.from("%PDF-1.4 fake"), {
+        filename: "document.pdf",
+        contentType: "application/pdf",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Only JPEG, PNG, and WebP/i);
+  });
+
+  // TC-04: Happy path — valid token + image, all services succeed
+  it("TC-04 | returns 200 with imageUrl on successful processing", async () => {
+    mockAuthSuccess();
+    mockStandardizeImage.mockResolvedValue("standardized-base64-string");
+    mockUploadToStorage.mockResolvedValue(
+      "https://storage.example.com/user-123/12345.png"
+    );
+
+    const res = await request(app)
+      .post("/api/prepare-image")
+      .set("Authorization", "Bearer valid-token")
+      .attach("image", Buffer.from("fake-jpeg-data"), {
+        filename: "shirt.jpg",
+        contentType: "image/jpeg",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.imageUrl).toBe(
+      "https://storage.example.com/user-123/12345.png"
+    );
+  });
+
+  // TC-05: Gemini throws — should surface as 500
+  it("TC-05 | returns 500 when Gemini standardizeImage service throws", async () => {
+    mockAuthSuccess();
+    mockStandardizeImage.mockRejectedValue(new Error("Gemini API unavailable"));
+
+    const res = await request(app)
+      .post("/api/prepare-image")
+      .set("Authorization", "Bearer valid-token")
+      .attach("image", Buffer.from("fake-jpeg-data"), {
+        filename: "shirt.jpg",
+        contentType: "image/jpeg",
+      });
+
+    expect(res.status).toBe(500);
+  });
+
+  // TC-06: prepare-image does NOT write to DB (two-step flow invariant)
+  it("TC-06 | prepare-image does not insert into the items table", async () => {
+    mockAuthSuccess();
+    mockStandardizeImage.mockResolvedValue("standardized-base64-string");
+    mockUploadToStorage.mockResolvedValue("https://storage.example.com/img.png");
+
+    await request(app)
+      .post("/api/prepare-image")
+      .set("Authorization", "Bearer valid-token")
+      .attach("image", Buffer.from("fake-jpeg-data"), {
+        filename: "shirt.jpg",
+        contentType: "image/jpeg",
+      });
+
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/confirm-image
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("POST /api/confirm-image", () => {
+  const app = buildApp();
+
+  // TC-07: No token
+  it("TC-07 | returns 401 when no Authorization header is provided", async () => {
+    const res = await request(app)
+      .post("/api/confirm-image")
+      .send({ imageUrl: "https://example.com/img.png", category: "tops" });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("no token");
+  });
+
+  // TC-08: Missing imageUrl
+  it("TC-08 | returns 400 when imageUrl is missing from request body", async () => {
+    mockAuthSuccess();
+
+    const res = await request(app)
+      .post("/api/confirm-image")
+      .set("Authorization", "Bearer valid-token")
+      .send({ category: "tops" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/imageUrl/i);
+  });
+
+  // TC-09: Missing category
+  it("TC-09 | returns 400 when category is missing from request body", async () => {
+    mockAuthSuccess();
+
+    const res = await request(app)
+      .post("/api/confirm-image")
+      .set("Authorization", "Bearer valid-token")
+      .send({ imageUrl: "https://example.com/img.png" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/category/i);
+  });
+
+  // TC-10: Happy path — required only; optional fields should insert as null
+  it("TC-10 | returns 200 and inserts null for omitted optional fields", async () => {
+    mockAuthSuccess("user-abc");
+    mockInsert.mockResolvedValue({ error: null });
+
+    const res = await request(app)
+      .post("/api/confirm-image")
+      .set("Authorization", "Bearer valid-token")
+      .send({ imageUrl: "https://example.com/img.png", category: "tops" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ subcategory: null, item_name: null })
+    );
+  });
+
+  // TC-11: Happy path — all fields including optional
+  it("TC-11 | inserts all fields correctly when subcategory and name are provided", async () => {
+    mockAuthSuccess("user-abc");
+    mockInsert.mockResolvedValue({ error: null });
+
+    await request(app)
+      .post("/api/confirm-image")
+      .set("Authorization", "Bearer valid-token")
+      .send({
+        imageUrl: "https://example.com/img.png",
+        category: "tops",
+        subcategory: "t-shirt",
+        name: "Blue Nike Tee",
+      });
+
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: "user-abc",
+        image_url: "https://example.com/img.png",
+        category: "tops",
+        subcategory: "t-shirt",
+        item_name: "Blue Nike Tee",
+      })
+    );
+  });
+
+  // TC-12: Supabase insert error
+  it("TC-12 | returns 500 with error message when Supabase insert fails", async () => {
+    mockAuthSuccess();
+    mockInsert.mockResolvedValue({ error: { message: "duplicate key value" } });
+
+    const res = await request(app)
+      .post("/api/confirm-image")
+      .set("Authorization", "Bearer valid-token")
+      .send({ imageUrl: "https://example.com/img.png", category: "tops" });
+
+    expect(res.status).toBe(500);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error).toBe("duplicate key value");
+  });
+
+  // TC-13: confirm-image does NOT process files (two-step flow invariant)
+  it("TC-13 | confirm-image does not call any file processing services", async () => {
+    mockAuthSuccess();
+    mockInsert.mockResolvedValue({ error: null });
+
+    await request(app)
+      .post("/api/confirm-image")
+      .set("Authorization", "Bearer valid-token")
+      .send({ imageUrl: "https://example.com/img.png", category: "tops" });
+
+    expect(mockUploadToStorage).not.toHaveBeenCalled();
+    expect(mockStandardizeImage).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/upload-image
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("POST /api/upload-image", () => {
+  const app = buildApp();
+
+  // TC-14: No token
+  it("TC-14 | returns 401 when no Authorization header is provided", async () => {
+    const res = await request(app)
+      .post("/api/upload-image")
+      .attach("image", Buffer.from("fake"), {
+        filename: "test.jpg",
+        contentType: "image/jpeg",
+      });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("no token");
+  });
+
+  // TC-15: Happy path — raw upload, skips AI entirely
+  it("TC-15 | returns 200 with imageUrl and does not call standardizeImage", async () => {
+    mockAuthSuccess();
+    mockUploadToStorage.mockResolvedValue(
+      "https://storage.example.com/user-123/raw.png"
+    );
+
+    const res = await request(app)
+      .post("/api/upload-image")
+      .set("Authorization", "Bearer valid-token")
+      .attach("image", Buffer.from("fake-image-data"), {
+        filename: "photo.jpg",
+        contentType: "image/jpeg",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.imageUrl).toBe(
+      "https://storage.example.com/user-123/raw.png"
+    );
+    expect(mockStandardizeImage).not.toHaveBeenCalled();
+  });
+});

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -16,7 +16,9 @@
         "@types/express": "^5.0.6",
         "@types/multer": "^2.1.0",
         "@types/node": "^25.9.1",
+        "@types/supertest": "^7.2.0",
         "nodemon": "^3.1.14",
+        "supertest": "^7.2.2",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.3"
       }
@@ -60,6 +62,29 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@supabase/auth-js": {
@@ -195,6 +220,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -234,6 +266,13 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -290,6 +329,30 @@
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.10",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.10.tgz",
+      "integrity": "sha512-nbt4IWXABhW0jGmmpRzCFNlbmwCTzZ2gTUsNIr+X+ItdqPms+PAJZbWsNzpS2USqXjcoNLQcO6nXo60zcPQiIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
+      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
       }
     },
     "node_modules/accepts": {
@@ -355,6 +418,20 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -511,6 +588,29 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
@@ -566,6 +666,13 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -607,6 +714,16 @@
         }
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -614,6 +731,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff": {
@@ -697,6 +825,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -755,6 +899,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -787,6 +938,64 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -908,6 +1117,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1081,6 +1306,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -1615,6 +1863,42 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {

--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,9 @@
     "@types/express": "^5.0.6",
     "@types/multer": "^2.1.0",
     "@types/node": "^25.9.1",
+    "@types/supertest": "^7.2.0",
     "nodemon": "^3.1.14",
+    "supertest": "^7.2.2",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.3"
   }


### PR DESCRIPTION
Adds unit test coverage for the upload router routes using Vitest with a mocked Supabase client and mocked service dependencies.

The tests cover
- missing and invalid auth token handling
- multer file type validation
- request body input validation
- successful image processing and DB insert responses
- key failure cases such as Gemini service errors and Supabase insert failures
- architectural invariants of the two-step prepare/confirm flow

All tests pass